### PR TITLE
[CAT-50] Modifier 의 클릭 관련 확장함수 / Preview 추가

### DIFF
--- a/app/src/main/java/com/pomonyang/MainActivity.kt
+++ b/app/src/main/java/com/pomonyang/MainActivity.kt
@@ -14,9 +14,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.pomonyang.data.remote.util.NetworkConnectivityManager
+import com.pomonyang.presentation.util.DevicePreviews
+import com.pomonyang.presentation.util.ThemePreviews
 import com.pomonyang.ui.theme.PomonyangTheme
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -75,7 +76,8 @@ fun Greeting(
     )
 }
 
-@Preview(showBackground = true)
+@DevicePreviews
+@ThemePreviews
 @Composable
 fun GreetingPreview() {
     PomonyangTheme {
@@ -83,7 +85,8 @@ fun GreetingPreview() {
     }
 }
 
-@Preview(showBackground = true)
+@DevicePreviews
+@ThemePreviews
 @Composable
 fun NetworkErrorScreenPreview() {
     PomonyangTheme {

--- a/presentation/src/main/java/com/pomonyang/presentation/util/ModifierUtils.kt
+++ b/presentation/src/main/java/com/pomonyang/presentation/util/ModifierUtils.kt
@@ -1,0 +1,91 @@
+package com.pomonyang.presentation.util
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.debounce
+
+/**
+ * 클릭 시 리플 효과가 없는 Modifier를 반환합니다.
+ */
+fun Modifier.noRippleClickable(onClick: () -> Unit): Modifier =
+    composed {
+        clickable(
+            indication = null,
+            interactionSource = remember { MutableInteractionSource() }
+        ) {
+            onClick()
+        }
+    }
+
+/**
+ * 클릭 이벤트를 디바운스 처리하여 여러 번 빠르게 클릭하는 것을 방지하고,
+ * @see noRippleClickable
+ * @param debounceTime 클릭 이벤트를 디바운스 처리할 시간 간격(밀리초). 기본값은 500ms.
+ */
+fun Modifier.debounceNoRippleClickable(
+    debounceTime: Long = 500L,
+    onClick: () -> Unit
+): Modifier =
+    composed {
+        debounceHandler(debounceTime = debounceTime) { debouncedOnClick ->
+            noRippleClickable {
+                debouncedOnClick(onClick)
+            }
+        }
+    }
+
+/**
+ * 클릭 이벤트를 디바운스 처리하여 여러 번 빠르게 클릭하는 것을 방지하는 Modifier를 반환합니다.
+ *
+ * @param debounceTime 클릭 이벤트를 디바운스 처리할 시간 간격(밀리초). 기본값은 500ms.
+ */
+fun Modifier.debounceClickable(
+    debounceTime: Long = 500L,
+    onClick: () -> Unit
+): Modifier =
+    composed {
+        debounceHandler(debounceTime = debounceTime) { debouncedOnClick ->
+            clickable {
+                debouncedOnClick(onClick)
+            }
+        }
+    }
+
+@Composable
+private fun <T> debounceHandler(
+    debounceTime: Long,
+    content: @Composable (DebouncedOnClick) -> T
+): T {
+    val eventFlow =
+        remember {
+            MutableSharedFlow<() -> Unit>(
+                replay = 0,
+                extraBufferCapacity = 1,
+                onBufferOverflow = BufferOverflow.DROP_OLDEST
+            )
+        }
+
+    val result =
+        content { event ->
+            eventFlow.tryEmit(event)
+        }
+
+    LaunchedEffect(Unit) {
+        eventFlow
+            .debounce(debounceTime)
+            .collect { event ->
+                event()
+            }
+    }
+
+    return result
+}
+
+typealias DebouncedOnClick = (() -> Unit) -> Unit

--- a/presentation/src/main/java/com/pomonyang/presentation/util/PreviewUtils.kt
+++ b/presentation/src/main/java/com/pomonyang/presentation/util/PreviewUtils.kt
@@ -1,0 +1,33 @@
+package com.pomonyang.presentation.util
+
+import android.content.res.Configuration
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+
+@Preview(
+    name = "LightTheme",
+    group = "Theme",
+    showBackground = true,
+    backgroundColor = 0xFFFFFFFF,
+    uiMode = Configuration.UI_MODE_NIGHT_NO
+)
+@Preview(
+    name = "DarkTheme",
+    group = "Theme",
+    showBackground = true,
+    backgroundColor = 0xFF000000,
+    uiMode = Configuration.UI_MODE_NIGHT_YES
+)
+annotation class ThemePreviews
+
+@Preview(
+    name = "Normal",
+    device = "spec:shape=Normal,width=1440,height=3200,unit=px,dpi=515",
+    showSystemUi = true
+)
+@Preview(
+    name = "Foldable",
+    device = Devices.FOLDABLE,
+    showSystemUi = true
+)
+annotation class DevicePreviews


### PR DESCRIPTION
## 작업 내용

- Ripple 효과 없는 Clickable 구현
- 연속 클릭에서 1번의 이벤트만 발생하게 해주는 DebounceClick 구현
- Theme / Device 관련한 Preview 추가

## 체크리스트
- [ ] 빌드 확인

## 동작 화면

### 프리뷰 예시

```kotlin
@ThemePreviews
@DevicePreviews
@Composable
fun GreetingPreview() {
    PomonyangTheme {
        Greeting("Android")
    }
}
```

<img width="658" alt="image" src="https://github.com/user-attachments/assets/d39a1664-0d72-43c5-bbd6-eb02e779e412">


## 살려주세요

