### PR TITLE
[CAT-105] colorScheme 추가 

### DIFF
--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/theme/Color.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/theme/Color.kt
@@ -1,11 +1,100 @@
 package com.pomonyang.mohanyang.presentation.theme
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import com.pomonyang.mohanyang.presentation.util.ThemePreviews
 
-val Purple80 = Color(0xFFD0BCFF)
-val PurpleGrey80 = Color(0xFFCCC2DC)
-val Pink80 = Color(0xFFEFB8C8)
+@Immutable
+object MohaNayangColor {
+    val White = Color(0xFFFFFFFF)
+    val Black = Color(0xFF000000)
 
-val Purple40 = Color(0xFF6650a4)
-val PurpleGrey40 = Color(0xFF625b71)
-val Pink40 = Color(0xFF7D5260)
+    val Gray50 = Color(0xFFFAF6F3)
+    val Gray100 = Color(0xFFF3EEEB)
+    val Gray200 = Color(0xFFDFD8D2)
+    val Gray300 = Color(0xFFB8AFA8)
+    val Gray400 = Color(0xFFA39A93)
+    val Gray500 = Color(0xFF8F867E)
+    val Gray600 = Color(0xFF665E57)
+    val Gray700 = Color(0xFF524A44)
+    val Gray800 = Color(0xFF3D3732)
+    val Gray900 = Color(0xFF292621)
+
+    val Orange50 = Color(0xFFFFF2E6)
+    val Orange100 = Color(0xFFFFDBBA)
+    val Orange200 = Color(0xFFFFC48E)
+    val Orange300 = Color(0xFFFFAD62)
+    val Orange400 = Color(0xFFFF9636)
+    val Orange500 = Color(0xFFF47A0A)
+    val Orange600 = Color(0xFFCB6100)
+    val Orange700 = Color(0xFFA24E00)
+    val Orange800 = Color(0xFF7A3A00)
+    val Orange900 = Color(0xFF512700)
+
+    val Red50 = Color(0xFFFFEBE7)
+    val Red100 = Color(0xFFFFC7BC)
+    val Red200 = Color(0xFFFFA290)
+    val Red300 = Color(0xFFFF7E65)
+    val Red400 = Color(0xFFFF5A3A)
+    val Red500 = Color(0xFFFE360F)
+    val Red600 = Color(0xFFD52300)
+    val Red700 = Color(0xFFAC1C00)
+    val Red800 = Color(0xFF841600)
+    val Red900 = Color(0xFF5B0F00)
+}
+
+@Immutable
+class MohaNyangColorScheme(
+    val primary: Color,
+    val secondary: Color,
+    val tertiary: Color,
+    val inverse: Color,
+    val disabled: Color = Color.Unspecified,
+    val accent1: Color = Color.Unspecified,
+    val accent2: Color = Color.Unspecified
+)
+
+private val MohaNyangIconColorScheme = MohaNyangColorScheme(
+    primary = MohaNayangColor.Gray700,
+    secondary = MohaNayangColor.Gray500,
+    tertiary = MohaNayangColor.Gray300,
+    disabled = MohaNayangColor.Gray200,
+    inverse = MohaNayangColor.White
+)
+
+private val MohaNyangTextColorScheme = MohaNyangColorScheme(
+    primary = MohaNayangColor.Gray800,
+    secondary = MohaNayangColor.Gray600,
+    tertiary = MohaNayangColor.Gray500,
+    disabled = MohaNayangColor.Gray300,
+    inverse = MohaNayangColor.White
+)
+
+private val MohaNyangBackgroundColorScheme = MohaNyangColorScheme(
+    primary = MohaNayangColor.Gray800,
+    secondary = MohaNayangColor.Gray600,
+    tertiary = MohaNayangColor.Gray500,
+    inverse = MohaNayangColor.White,
+    accent1 = MohaNayangColor.Orange500,
+    accent2 = MohaNayangColor.Orange50
+)
+
+val LocalMohaNyangIconColorScheme = staticCompositionLocalOf { MohaNyangIconColorScheme }
+val LocalMohaNyangTextColorScheme = staticCompositionLocalOf { MohaNyangTextColorScheme }
+val LocalMohaNyangBackgroundColorScheme = staticCompositionLocalOf { MohaNyangBackgroundColorScheme }
+
+@ThemePreviews
+@Composable
+private fun MohaNyangColorSchemePreview() {
+    MohaNyangTheme {
+        Column(modifier = Modifier.background(MohaNyangTheme.backgroundColorScheme.accent1)) {
+            Text(text = "test", color = MohaNyangTheme.textColorScheme.inverse)
+        }
+    }
+}

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/theme/Color.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/theme/Color.kt
@@ -77,10 +77,10 @@ private val MohaNyangTextColorScheme = MohaNyangColorScheme(
 )
 
 private val MohaNyangBackgroundColorScheme = MohaNyangColorScheme(
-    primary = MohaNayangColor.Gray800,
-    secondary = MohaNayangColor.Gray600,
-    tertiary = MohaNayangColor.Gray500,
-    inverse = MohaNayangColor.White,
+    primary = MohaNayangColor.Gray500,
+    secondary = MohaNayangColor.Gray100,
+    tertiary = MohaNayangColor.Gray400,
+    inverse = MohaNayangColor.Gray900,
     accent1 = MohaNayangColor.Orange500,
     accent2 = MohaNayangColor.Orange50
 )

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/theme/Theme.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/theme/Theme.kt
@@ -1,50 +1,39 @@
 package com.pomonyang.mohanyang.presentation.theme
 
-import android.os.Build
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.darkColorScheme
-import androidx.compose.material3.dynamicDarkColorScheme
-import androidx.compose.material3.dynamicLightColorScheme
-import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
-
-private val DarkColorScheme =
-    darkColorScheme(
-        primary = Purple80,
-        secondary = PurpleGrey80,
-        tertiary = Pink80
-    )
-
-private val LightColorScheme =
-    lightColorScheme(
-        primary = Purple40,
-        secondary = PurpleGrey40,
-        tertiary = Pink40
-    )
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ReadOnlyComposable
 
 @Composable
 fun MohaNyangTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colorScheme =
-        when {
-            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-                val context = LocalContext.current
-                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-            }
+    CompositionLocalProvider(
+        LocalMohaNyangIconColorScheme provides MohaNyangTheme.iconColorScheme,
+        LocalMohaNyangBackgroundColorScheme provides MohaNyangTheme.backgroundColorScheme,
+        LocalMohaNyangTextColorScheme provides MohaNyangTheme.textColorScheme
+    ) {
+        MaterialTheme(
+            typography = Typography,
+            content = content
+        )
+    }
+}
 
-            darkTheme -> DarkColorScheme
-            else -> LightColorScheme
-        }
+object MohaNyangTheme {
+    val iconColorScheme: MohaNyangColorScheme
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalMohaNyangIconColorScheme.current
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = Typography,
-        content = content
-    )
+    val backgroundColorScheme: MohaNyangColorScheme
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalMohaNyangBackgroundColorScheme.current
+
+    val textColorScheme: MohaNyangColorScheme
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalMohaNyangTextColorScheme.current
 }


### PR DESCRIPTION
## 작업 내용

[figma](https://www.figma.com/design/2HuhQQqKTYg2vWpRnvPKDI/%EB%BD%80%EB%AA%A8%EB%83%A5-%EB%94%94%EC%9E%90%EC%9D%B8%EC%8B%9C%EC%8A%A4%ED%85%9C?node-id=110-1892&t=UcMZd5LYwzMq1PP5-4)

![image](https://github.com/user-attachments/assets/124be1d8-cbd2-4232-8e39-f43bce5372bc)

- 1개의 ColorScheme으로 전부 대응하기가 불가능해서 3개의 colorScheme을 LocalProvide 하는 형태로 구현 


## 체크리스트
- [ ] 빌드 확인

## 동작 화면

<img width="267" alt="image" src="https://github.com/user-attachments/assets/785cd12a-ffab-4506-9737-0d5a891ba96b">

> theme 안에서 provide한게 정상적으로 동작하는지 확인

## 살려주세요

