### PR TITLE
[CAT-140] MnTopAppBar 구현 / Icon LocalContentColor로 수정

### DIFF
--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/icon/MnLargeIcon.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/icon/MnLargeIcon.kt
@@ -3,21 +3,38 @@ package com.pomonyang.mohanyang.presentation.designsystem.icon
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnIconSize
 
 @Composable
 fun MnLargeIcon(
-    modifier: Modifier = Modifier,
     @DrawableRes resourceId: Int,
+    modifier: Modifier = Modifier,
     contentDescription: String? = null,
-    tint: Color = Color.Unspecified
+    tint: Color = LocalContentColor.current
 ) {
     Icon(
         painter = painterResource(id = resourceId),
+        contentDescription = contentDescription,
+        modifier = modifier.size(MnIconSize.large),
+        tint = tint
+    )
+}
+
+@Composable
+fun MnLargeIcon(
+    imageVector: ImageVector,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    tint: Color = LocalContentColor.current
+) {
+    Icon(
+        imageVector = imageVector,
         contentDescription = contentDescription,
         modifier = modifier.size(MnIconSize.large),
         tint = tint

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/icon/MnMediumIcon.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/icon/MnMediumIcon.kt
@@ -3,21 +3,38 @@ package com.pomonyang.mohanyang.presentation.designsystem.icon
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnIconSize
 
 @Composable
 fun MnMediumIcon(
-    modifier: Modifier = Modifier,
     @DrawableRes resourceId: Int,
+    modifier: Modifier = Modifier,
     contentDescription: String? = null,
-    tint: Color = Color.Unspecified
+    tint: Color = LocalContentColor.current
 ) {
     Icon(
         painter = painterResource(id = resourceId),
+        contentDescription = contentDescription,
+        modifier = modifier.size(MnIconSize.medium),
+        tint = tint
+    )
+}
+
+@Composable
+fun MnMediumIcon(
+    imageVector: ImageVector,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    tint: Color = LocalContentColor.current
+) {
+    Icon(
+        imageVector = imageVector,
         contentDescription = contentDescription,
         modifier = modifier.size(MnIconSize.medium),
         tint = tint

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/icon/MnSmallIcon.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/icon/MnSmallIcon.kt
@@ -3,21 +3,38 @@ package com.pomonyang.mohanyang.presentation.designsystem.icon
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnIconSize
 
 @Composable
 fun MnSmallIcon(
-    modifier: Modifier = Modifier,
     @DrawableRes resourceId: Int,
+    modifier: Modifier = Modifier,
     contentDescription: String? = null,
-    tint: Color = Color.Unspecified
+    tint: Color = LocalContentColor.current
 ) {
     Icon(
         painter = painterResource(id = resourceId),
+        contentDescription = contentDescription,
+        modifier = modifier.size(MnIconSize.small),
+        tint = tint
+    )
+}
+
+@Composable
+fun MnSmallIcon(
+    imageVector: ImageVector,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    tint: Color = LocalContentColor.current
+) {
+    Icon(
+        imageVector = imageVector,
         contentDescription = contentDescription,
         modifier = modifier.size(MnIconSize.small),
         tint = tint

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/icon/MnXLargeIcon.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/icon/MnXLargeIcon.kt
@@ -3,21 +3,38 @@ package com.pomonyang.mohanyang.presentation.designsystem.icon
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnIconSize
 
 @Composable
 fun MnXLargeIcon(
-    modifier: Modifier = Modifier,
     @DrawableRes resourceId: Int,
+    modifier: Modifier = Modifier,
     contentDescription: String? = null,
-    tint: Color = Color.Unspecified
+    tint: Color = LocalContentColor.current
 ) {
     Icon(
         painter = painterResource(id = resourceId),
+        contentDescription = contentDescription,
+        modifier = modifier.size(MnIconSize.xLarge),
+        tint = tint
+    )
+}
+
+@Composable
+fun MnXLargeIcon(
+    imageVector: ImageVector,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    tint: Color = LocalContentColor.current
+) {
+    Icon(
+        imageVector = imageVector,
         contentDescription = contentDescription,
         modifier = modifier.size(MnIconSize.xLarge),
         tint = tint

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/icon/MnXSmallIcon.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/icon/MnXSmallIcon.kt
@@ -3,21 +3,38 @@ package com.pomonyang.mohanyang.presentation.designsystem.icon
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnIconSize
 
 @Composable
 fun MnXSmallIcon(
-    modifier: Modifier = Modifier,
     @DrawableRes resourceId: Int,
+    modifier: Modifier = Modifier,
     contentDescription: String? = null,
-    tint: Color = Color.Unspecified
+    tint: Color = LocalContentColor.current
 ) {
     Icon(
         painter = painterResource(id = resourceId),
+        contentDescription = contentDescription,
+        modifier = modifier.size(MnIconSize.xSmall),
+        tint = tint
+    )
+}
+
+@Composable
+fun MnXSmallIcon(
+    imageVector: ImageVector,
+    modifier: Modifier = Modifier,
+    contentDescription: String? = null,
+    tint: Color = LocalContentColor.current
+) {
+    Icon(
+        imageVector = imageVector,
         contentDescription = contentDescription,
         modifier = modifier.size(MnIconSize.xSmall),
         tint = tint

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/token/MnColor.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/token/MnColor.kt
@@ -78,7 +78,7 @@ private val MnTextColorScheme = MnColorScheme(
 )
 
 private val MnBackgroundColorScheme = MnColorScheme(
-    primary = MnColor.Gray500,
+    primary = MnColor.Gray50,
     secondary = MnColor.Gray100,
     tertiary = MnColor.Gray400,
     inverse = MnColor.Gray900,

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/topappbar/MnTopAppBar.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/topappbar/MnTopAppBar.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
@@ -18,11 +17,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.layout.layoutId
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mohanyang.presentation.R
 import com.pomonyang.mohanyang.presentation.designsystem.icon.MnMediumIcon
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
-import com.pomonyang.mohanyang.presentation.util.ThemePreviews
 import com.pomonyang.mohanyang.presentation.util.dpToPx
 import com.pomonyang.mohanyang.presentation.util.noRippleClickable
 
@@ -37,6 +36,7 @@ fun MnTopAppBar(
     actions: @Composable () -> Unit = {}
 ) {
     val iconHorizontalPadding = MnTopAppBarDefaults.iconHorizontalPadding.dpToPx().toInt()
+    val topAppBarHeightToPx = MnTopAppBarDefaults.height.dpToPx().toInt()
     Layout(
         content = {
             Box(Modifier.layoutId(NAVIGATION_ICON)) {
@@ -59,19 +59,17 @@ fun MnTopAppBar(
                 )
             }
         },
-        modifier = modifier
-            .windowInsetsPadding(windowInsets)
-            .background(topAppBarColors.containerColor)
+        modifier = modifier.background(topAppBarColors.containerColor)
     ) { measurables, constraints ->
         val navigationIconPlaceable = measurables.first { it.layoutId == NAVIGATION_ICON }.measure(constraints)
         val actionsPlaceable = measurables.first { it.layoutId == ACTIONS }.measure(constraints)
         val contentPlaceable = measurables.first { it.layoutId == CONTENT }.measure(constraints)
 
-        layout(constraints.maxWidth, MnTopAppBarDefaults.height.toPx().toInt()) {
-            navigationIconPlaceable.placeRelative(iconHorizontalPadding, (constraints.maxHeight - navigationIconPlaceable.height) / 2)
-            actionsPlaceable.placeRelative(constraints.maxWidth - actionsPlaceable.width - iconHorizontalPadding, (constraints.maxHeight - actionsPlaceable.height) / 2)
+        layout(constraints.maxWidth, topAppBarHeightToPx) {
+            navigationIconPlaceable.place(iconHorizontalPadding, (topAppBarHeightToPx - navigationIconPlaceable.height) / 2)
+            actionsPlaceable.place(constraints.maxWidth - actionsPlaceable.width - iconHorizontalPadding, (topAppBarHeightToPx - actionsPlaceable.height) / 2)
             val contentX = (constraints.maxWidth - contentPlaceable.width) / 2
-            contentPlaceable.placeRelative(contentX, (constraints.maxHeight - contentPlaceable.height) / 2)
+            contentPlaceable.place(contentX, (topAppBarHeightToPx - contentPlaceable.height) / 2)
         }
     }
 }
@@ -80,7 +78,7 @@ private const val NAVIGATION_ICON = "navigationIcon"
 private const val ACTIONS = "actions"
 private const val CONTENT = "content"
 
-@ThemePreviews
+@Preview
 @Composable
 private fun MnTopAppBarPreview() {
     MnTheme {
@@ -101,6 +99,58 @@ private fun MnTopAppBarPreview() {
                         tint = topAppBarColors.navigationIconContentColor
                     )
                 }
+            },
+            actions = {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .noRippleClickable { },
+                    contentAlignment = Alignment.Center
+                ) {
+                    MnMediumIcon(
+                        resourceId = R.drawable.ic_null,
+                        tint = topAppBarColors.navigationIconContentColor
+                    )
+                }
+            }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun MnTopAppBarNotUseActionsPreview() {
+    MnTheme {
+        val topAppBarColors = MnTopAppBarDefaults.topAppBarColors()
+        MnTopAppBar(
+            content = {
+                Text("Title")
+            },
+            navigationIcon = {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .noRippleClickable { },
+                    contentAlignment = Alignment.Center
+                ) {
+                    MnMediumIcon(
+                        resourceId = R.drawable.ic_null,
+                        tint = topAppBarColors.navigationIconContentColor
+                    )
+                }
+            }
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun MnTopAppBarNotUseNaivigationPreview() {
+    MnTheme {
+        val topAppBarColors = MnTopAppBarDefaults.topAppBarColors()
+        MnTopAppBar(
+            content = {
+                Text("Title")
             },
             actions = {
                 Box(

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/topappbar/MnTopAppBar.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/topappbar/MnTopAppBar.kt
@@ -1,0 +1,120 @@
+package com.pomonyang.mohanyang.presentation.designsystem.topappbar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.Layout
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import com.mohanyang.presentation.R
+import com.pomonyang.mohanyang.presentation.designsystem.icon.MnMediumIcon
+import com.pomonyang.mohanyang.presentation.theme.MnTheme
+import com.pomonyang.mohanyang.presentation.util.ThemePreviews
+import com.pomonyang.mohanyang.presentation.util.dpToPx
+import com.pomonyang.mohanyang.presentation.util.noRippleClickable
+
+@Composable
+fun MnTopAppBar(
+    modifier: Modifier = Modifier,
+    contentStyle: TextStyle = MnTheme.typography.bodySemiBold,
+    topAppBarColors: MnAppBarColors = MnTopAppBarDefaults.topAppBarColors(),
+    windowInsets: WindowInsets = WindowInsets.systemBars.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Top),
+    content: @Composable () -> Unit = {},
+    navigationIcon: @Composable () -> Unit = {},
+    actions: @Composable () -> Unit = {}
+) {
+    val iconHorizontalPadding = MnTopAppBarDefaults.iconHorizontalPadding.dpToPx().toInt()
+    Layout(
+        content = {
+            Box(Modifier.layoutId(NAVIGATION_ICON)) {
+                CompositionLocalProvider(
+                    value = LocalContentColor provides topAppBarColors.navigationIconContentColor,
+                    content = navigationIcon
+                )
+            }
+            Box(Modifier.layoutId(ACTIONS)) {
+                CompositionLocalProvider(
+                    value = LocalContentColor provides topAppBarColors.actionIconContentColor,
+                    content = actions
+                )
+            }
+            Box(Modifier.layoutId(CONTENT)) {
+                CompositionLocalProvider(
+                    LocalContentColor provides topAppBarColors.titleContentColor,
+                    LocalTextStyle provides contentStyle,
+                    content = content
+                )
+            }
+        },
+        modifier = modifier
+            .windowInsetsPadding(windowInsets)
+            .background(topAppBarColors.containerColor)
+    ) { measurables, constraints ->
+        val navigationIconPlaceable = measurables.first { it.layoutId == NAVIGATION_ICON }.measure(constraints)
+        val actionsPlaceable = measurables.first { it.layoutId == ACTIONS }.measure(constraints)
+        val contentPlaceable = measurables.first { it.layoutId == CONTENT }.measure(constraints)
+
+        layout(constraints.maxWidth, MnTopAppBarDefaults.height.toPx().toInt()) {
+            navigationIconPlaceable.placeRelative(iconHorizontalPadding, (constraints.maxHeight - navigationIconPlaceable.height) / 2)
+            actionsPlaceable.placeRelative(constraints.maxWidth - actionsPlaceable.width - iconHorizontalPadding, (constraints.maxHeight - actionsPlaceable.height) / 2)
+            val contentX = (constraints.maxWidth - contentPlaceable.width) / 2
+            contentPlaceable.placeRelative(contentX, (constraints.maxHeight - contentPlaceable.height) / 2)
+        }
+    }
+}
+
+private const val NAVIGATION_ICON = "navigationIcon"
+private const val ACTIONS = "actions"
+private const val CONTENT = "content"
+
+@ThemePreviews
+@Composable
+private fun MnTopAppBarPreview() {
+    MnTheme {
+        val topAppBarColors = MnTopAppBarDefaults.topAppBarColors()
+        MnTopAppBar(
+            content = {
+                Text("Title")
+            },
+            navigationIcon = {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .noRippleClickable { },
+                    contentAlignment = Alignment.Center
+                ) {
+                    MnMediumIcon(
+                        resourceId = R.drawable.ic_null,
+                        tint = topAppBarColors.navigationIconContentColor
+                    )
+                }
+            },
+            actions = {
+                Box(
+                    modifier = Modifier
+                        .size(40.dp)
+                        .noRippleClickable { },
+                    contentAlignment = Alignment.Center
+                ) {
+                    MnMediumIcon(
+                        resourceId = R.drawable.ic_null,
+                        tint = topAppBarColors.navigationIconContentColor
+                    )
+                }
+            }
+        )
+    }
+}

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/topappbar/MnTopAppBar.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/topappbar/MnTopAppBar.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Text
@@ -59,7 +60,9 @@ fun MnTopAppBar(
                 )
             }
         },
-        modifier = modifier.background(topAppBarColors.containerColor)
+        modifier = modifier
+            .windowInsetsPadding(windowInsets)
+            .background(topAppBarColors.containerColor)
     ) { measurables, constraints ->
         val navigationIconPlaceable = measurables.first { it.layoutId == NAVIGATION_ICON }.measure(constraints)
         val actionsPlaceable = measurables.first { it.layoutId == ACTIONS }.measure(constraints)

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/topappbar/MnTopAppBarDefaults.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/topappbar/MnTopAppBarDefaults.kt
@@ -1,0 +1,34 @@
+package com.pomonyang.mohanyang.presentation.designsystem.topappbar
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.pomonyang.mohanyang.presentation.designsystem.token.MnColor
+import com.pomonyang.mohanyang.presentation.theme.MnTheme
+
+object MnTopAppBarDefaults {
+    val height = 56.dp
+    val iconHorizontalPadding = 8.dp
+
+    @Composable
+    fun topAppBarColors(
+        containerColor: Color = MnColor.Gray50,
+        navigationIconContentColor: Color = MnTheme.iconColorScheme.primary,
+        titleContentColor: Color = MnTheme.textColorScheme.primary,
+        actionIconContentColor: Color = MnTheme.iconColorScheme.primary
+    ) = MnAppBarColors(
+        containerColor = containerColor,
+        navigationIconContentColor = navigationIconContentColor,
+        titleContentColor = titleContentColor,
+        actionIconContentColor = actionIconContentColor
+    )
+}
+
+@Immutable
+data class MnAppBarColors(
+    val containerColor: Color,
+    val navigationIconContentColor: Color,
+    val titleContentColor: Color,
+    val actionIconContentColor: Color
+)


### PR DESCRIPTION
## 작업 내용

> M3 TopAppBar를 사용하려다가 `ExperimentalMaterial3Api` 이라서 그런지 불안전해보여서 내부 코드 조금 보면서 내가 그냥 Layout 만들었어

[figma-link](https://www.figma.com/design/2HuhQQqKTYg2vWpRnvPKDI/%EB%BD%80%EB%AA%A8%EB%83%A5-%EB%94%94%EC%9E%90%EC%9D%B8%EC%8B%9C%EC%8A%A4%ED%85%9C?node-id=78-379&t=5LQrOx0MjzoO9cF7-4)

MnTopAppBar 구현했으며 3가지를 고려
  1. Title만 있는 경우
  2. NavigationIcon만 있는 경우
  3. Actions만 있는 경우


## 체크리스트
- [ ] 빌드 확인

## 동작 화면

<img width="428" alt="image" src="https://github.com/user-attachments/assets/e1247758-34b1-46a8-b38a-5627dcb720d8">


## 살려주세요

