### PR TITLE
[CAT-148] 뽀모도르 시작하기 UI 틀 구현

### DIFF
--- a/app/src/main/java/com/pomonyang/mohanyang/navigation/MohaNyangNavHost.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/navigation/MohaNyangNavHost.kt
@@ -36,6 +36,10 @@ internal fun MohaNyangNavHost(
             coroutineScope.launch { onShowSnackbar("arrived at the home screen.", null) }
             navHostController.navigate(Home)
         }
-        homeScreen(navigateUp = navigateUp)
+        homeScreen(
+            navigateUp = navigateUp,
+            isNewUser = mohaNyangAppState.isNewUser,
+            navHostController = mohaNyangAppState.navHostController
+        )
     }
 }

--- a/app/src/main/java/com/pomonyang/mohanyang/navigation/MohaNyangNavHost.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/navigation/MohaNyangNavHost.kt
@@ -8,6 +8,7 @@ import com.pomonyang.mohanyang.presentation.screen.home.Home
 import com.pomonyang.mohanyang.presentation.screen.home.homeScreen
 import com.pomonyang.mohanyang.presentation.screen.onboarding.Onboarding
 import com.pomonyang.mohanyang.presentation.screen.onboarding.onboardingScreen
+import com.pomonyang.mohanyang.presentation.screen.pomodoro.setting.pomodoroSettingScreen
 import com.pomonyang.mohanyang.ui.MohaNyangAppState
 import kotlinx.coroutines.launch
 
@@ -36,10 +37,12 @@ internal fun MohaNyangNavHost(
             coroutineScope.launch { onShowSnackbar("arrived at the home screen.", null) }
             navHostController.navigate(Home)
         }
+
         homeScreen(
             navigateUp = navigateUp,
-            isNewUser = mohaNyangAppState.isNewUser,
             navHostController = mohaNyangAppState.navHostController
         )
+
+        pomodoroSettingScreen(isNewUser = mohaNyangAppState.isNewUser)
     }
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/tooltip/MnTooltip.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/tooltip/MnTooltip.kt
@@ -91,6 +91,7 @@ import kotlinx.coroutines.delay
 @Composable
 fun Modifier.tooltip(
     content: String,
+    modifier: Modifier = Modifier,
     tooltipColors: MnTooltipColors = MnTooltipDefaults.lightTooltipColors(),
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     verticalAlignment: Alignment.Vertical = Alignment.Top,
@@ -132,11 +133,13 @@ fun Modifier.tooltip(
         label = "tooltip transition"
     )
     if (enabled) {
-        HandleSystemBarsColor(activity?.window)
+        if (showOverlay) {
+            HandleSystemBarsColor(window = activity?.window)
+        }
 
         Popup {
             Box(
-                modifier = Modifier
+                modifier = modifier
                     .fillMaxSize()
                     .drawOverlayBackground(
                         showOverlay = showOverlay,

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/tooltip/MnTooltipDefaults.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/tooltip/MnTooltipDefaults.kt
@@ -24,7 +24,7 @@ object MnTooltipDefaults {
     @Composable
     fun darkTooltipColors(
         containerColor: Color = MnTheme.backgroundColorScheme.inverse,
-        contentColor: Color = MnTheme.iconColorScheme.inverse
+        contentColor: Color = MnTheme.textColorScheme.inverse
     ) = MnTooltipColors(
         containerColor = containerColor,
         contentColor = contentColor

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/HomeNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/HomeNavigator.kt
@@ -1,16 +1,26 @@
 package com.pomonyang.mohanyang.presentation.screen.home
 
 import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
+import com.pomonyang.mohanyang.presentation.screen.pomodoro.setting.PomodoroSetting
+import com.pomonyang.mohanyang.presentation.screen.pomodoro.setting.pomodoroSettingScreen
 import kotlinx.serialization.Serializable
 
 @Serializable
 data object Home
 
-fun NavGraphBuilder.homeScreen(navigateUp: () -> Unit) {
+fun NavGraphBuilder.homeScreen(
+    navigateUp: () -> Unit,
+    isNewUser: Boolean,
+    navHostController: NavHostController
+) {
     composable<Home> {
         HomeRoute(
-            onNavigationClick = navigateUp
+            onNavigationClick = navigateUp,
+            onPomodoroSettingClick = { navHostController.navigate(PomodoroSetting) }
         )
     }
+
+    pomodoroSettingScreen(isNewUser)
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/HomeNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/HomeNavigator.kt
@@ -4,7 +4,6 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.setting.PomodoroSetting
-import com.pomonyang.mohanyang.presentation.screen.pomodoro.setting.pomodoroSettingScreen
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -12,7 +11,6 @@ data object Home
 
 fun NavGraphBuilder.homeScreen(
     navigateUp: () -> Unit,
-    isNewUser: Boolean,
     navHostController: NavHostController
 ) {
     composable<Home> {
@@ -21,6 +19,4 @@ fun NavGraphBuilder.homeScreen(
             onPomodoroSettingClick = { navHostController.navigate(PomodoroSetting) }
         )
     }
-
-    pomodoroSettingScreen(isNewUser)
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/HomeScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/HomeScreen.kt
@@ -1,39 +1,47 @@
 package com.pomonyang.mohanyang.presentation.screen.home
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.DevicePreviews
 import com.pomonyang.mohanyang.presentation.util.ThemePreviews
-import com.pomonyang.mohanyang.presentation.util.debounceNoRippleClickable
 
 @Composable
 internal fun HomeRoute(
     onNavigationClick: () -> Unit,
+    onPomodoroSettingClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     HomeScreen(
         modifier = modifier,
-        onNavigationClick = onNavigationClick
+        onNavigationClick = onNavigationClick,
+        onPomodoroSettingClick = onPomodoroSettingClick
     )
 }
 
 @Composable
 private fun HomeScreen(
-    modifier: Modifier = Modifier,
-    onNavigationClick: () -> Unit
+    onNavigationClick: () -> Unit,
+    onPomodoroSettingClick: () -> Unit,
+    modifier: Modifier = Modifier
 ) {
-    Box(
+    Column(
         modifier = modifier.fillMaxSize(),
-        contentAlignment = Alignment.Center
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text(
-            text = "back",
-            modifier = Modifier.debounceNoRippleClickable { onNavigationClick() }
-        )
+        Button(onNavigationClick) {
+            Text(text = "back")
+        }
+        Button(onPomodoroSettingClick) {
+            Text(text = "go pomodoro setting")
+        }
     }
 }
 
@@ -41,6 +49,10 @@ private fun HomeScreen(
 @DevicePreviews
 @Composable
 private fun HomeScreenPreview() {
-    // TODO [코니] set theme
-    HomeScreen {}
+    MnTheme {
+        HomeScreen(
+            onPomodoroSettingClick = {},
+            onNavigationClick = {}
+        )
+    }
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingNavigator.kt
@@ -2,14 +2,13 @@ package com.pomonyang.mohanyang.presentation.screen.pomodoro.setting
 
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import com.pomonyang.mohanyang.presentation.screen.home.Home
 import kotlinx.serialization.Serializable
 
 @Serializable
 data object PomodoroSetting
 
 fun NavGraphBuilder.pomodoroSettingScreen(isNewUser: Boolean) {
-    composable<Home> {
+    composable<PomodoroSetting> {
         PomodoroSettingRoute(isNewUser)
     }
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingNavigator.kt
@@ -1,0 +1,15 @@
+package com.pomonyang.mohanyang.presentation.screen.pomodoro.setting
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.pomonyang.mohanyang.presentation.screen.home.Home
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object PomodoroSetting
+
+fun NavGraphBuilder.pomodoroSettingScreen(isNewUser: Boolean) {
+    composable<Home> {
+        PomodoroSettingRoute(isNewUser)
+    }
+}

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingScreen.kt
@@ -1,4 +1,4 @@
-package com.pomonyang.mohanyang.presentation.screen.pomodoro.start
+package com.pomonyang.mohanyang.presentation.screen.pomodoro.setting
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -43,15 +43,15 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 @Composable
-fun PomodoroStarterRoute(
+fun PomodoroSettingRoute(
     isNewUser: Boolean, // TODO [지훈] ViewModel의 State로 변경 예정
     modifier: Modifier = Modifier
 ) {
-    PomodoroStarterScreen(modifier = modifier, isNewUser = isNewUser)
+    PomodoroSettingScreen(modifier = modifier, isNewUser = isNewUser)
 }
 
 @Composable
-fun PomodoroStarterScreen(
+fun PomodoroSettingScreen(
     isNewUser: Boolean,
     modifier: Modifier = Modifier
 ) {
@@ -250,7 +250,7 @@ private fun StartButton() {
 @Composable
 @Preview
 fun PomodoroStarterScreenPreview() {
-    PomodoroStarterScreen(isNewUser = false)
+    PomodoroSettingScreen(isNewUser = false)
 }
 
 @Composable

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/start/PomodoroStartScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/start/PomodoroStartScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -17,6 +18,11 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -29,19 +35,24 @@ import com.pomonyang.mohanyang.presentation.designsystem.icon.MnMediumIcon
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnColor
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnRadius
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
+import com.pomonyang.mohanyang.presentation.designsystem.tooltip.tooltip
 import com.pomonyang.mohanyang.presentation.designsystem.topappbar.MnTopAppBar
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.noRippleClickable
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 @Composable
 fun PomodoroStarterRoute(
+    isNewUser: Boolean, // TODO [지훈] ViewModel의 State로 변경 예정
     modifier: Modifier = Modifier
 ) {
-    PomodoroStarterScreen(modifier = modifier)
+    PomodoroStarterScreen(modifier = modifier, isNewUser = isNewUser)
 }
 
 @Composable
 fun PomodoroStarterScreen(
+    isNewUser: Boolean,
     modifier: Modifier = Modifier
 ) {
     Scaffold(
@@ -74,7 +85,7 @@ fun PomodoroStarterScreen(
             verticalArrangement = Arrangement.spacedBy(25.dp)
         ) {
             CatRiveBox()
-            FocusBox()
+            FocusBox(isNewUser)
             StartButton()
         }
     }
@@ -93,17 +104,45 @@ private fun CatRiveBox() {
 
 @Composable
 private fun FocusBox(
+    isNewUser: Boolean,
     modifier: Modifier = Modifier
 ) {
+    var categoryTooltip by remember { mutableStateOf(isNewUser) }
+    var timeTooltip by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+
     Column(
         modifier = modifier.padding(vertical = MnSpacing.large),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(MnSpacing.medium)
+        horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        CategoryBox()
+        CategoryBox(
+            modifier = Modifier
+                .padding(bottom = MnSpacing.medium)
+                .tooltip(
+                    enabled = categoryTooltip,
+                    content = stringResource(R.string.tooltip_category_content),
+                    anchorPadding = PaddingValues(bottom = MnSpacing.medium),
+                    ovalShape = MnRadius.xSmall,
+                    onDismiss = {
+                        coroutineScope.launch {
+                            categoryTooltip = false
+                            delay(250)
+                            timeTooltip = true
+                        }
+                    }
+                )
+        )
 
         Row(
-            modifier = Modifier.padding(horizontal = MnSpacing.twoXLarge),
+            modifier = Modifier
+                .padding(horizontal = MnSpacing.twoXLarge)
+                .tooltip(
+                    enabled = timeTooltip,
+                    content = stringResource(R.string.tooltip_time_content),
+                    anchorPadding = PaddingValues(bottom = MnSpacing.medium),
+                    ovalShape = MnRadius.xSmall,
+                    onDismiss = { timeTooltip = false }
+                ),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(MnSpacing.medium)
         ) {
@@ -202,7 +241,7 @@ private fun StartButton() {
 @Composable
 @Preview
 fun PomodoroStarterScreenPreview() {
-    PomodoroStarterScreen()
+    PomodoroStarterScreen(isNewUser = false)
 }
 
 @Composable
@@ -214,7 +253,7 @@ fun CatImagePreview() {
 @Composable
 @Preview(showBackground = true)
 fun FocusBoxPreview() {
-    FocusBox()
+    FocusBox(isNewUser = false)
 }
 
 @Composable

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/start/PomodoroStartScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/start/PomodoroStartScreen.kt
@@ -84,26 +84,35 @@ fun PomodoroStarterScreen(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(25.dp)
         ) {
-            CatRiveBox()
-            FocusBox(isNewUser)
+            CatRive()
+            PomodoroDetailSetting(isNewUser)
             StartButton()
         }
     }
 }
 
 @Composable
-private fun CatRiveBox() {
+private fun CatRive(
+    showTooltip: Boolean = false
+) {
     Box(
         modifier = Modifier
             .size(240.dp)
             .background(MnTheme.backgroundColorScheme.secondary)
+            .tooltip(
+                modifier = Modifier.padding(top = 20.dp),
+                enabled = showTooltip,
+                content = stringResource(R.string.tooltip_rest_content),
+                showOverlay = false,
+                highlightComponent = false
+            )
     ) {
         // TODO
     }
 }
 
 @Composable
-private fun FocusBox(
+private fun PomodoroDetailSetting(
     isNewUser: Boolean,
     modifier: Modifier = Modifier
 ) {
@@ -247,13 +256,13 @@ fun PomodoroStarterScreenPreview() {
 @Composable
 @Preview
 fun CatImagePreview() {
-    CatRiveBox()
+    CatRive()
 }
 
 @Composable
 @Preview(showBackground = true)
 fun FocusBoxPreview() {
-    FocusBox(isNewUser = false)
+    PomodoroDetailSetting(isNewUser = false)
 }
 
 @Composable

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/start/PomodoroStartScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/start/PomodoroStartScreen.kt
@@ -1,0 +1,224 @@
+package com.pomonyang.mohanyang.presentation.screen.pomodoro.start
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.mohanyang.presentation.R
+import com.pomonyang.mohanyang.presentation.designsystem.icon.MnLargeIcon
+import com.pomonyang.mohanyang.presentation.designsystem.icon.MnMediumIcon
+import com.pomonyang.mohanyang.presentation.designsystem.token.MnColor
+import com.pomonyang.mohanyang.presentation.designsystem.token.MnRadius
+import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
+import com.pomonyang.mohanyang.presentation.designsystem.topappbar.MnTopAppBar
+import com.pomonyang.mohanyang.presentation.theme.MnTheme
+import com.pomonyang.mohanyang.presentation.util.noRippleClickable
+
+@Composable
+fun PomodoroStarterRoute(
+    modifier: Modifier = Modifier
+) {
+    PomodoroStarterScreen(modifier = modifier)
+}
+
+@Composable
+fun PomodoroStarterScreen(
+    modifier: Modifier = Modifier
+) {
+    Scaffold(
+        modifier = modifier,
+        containerColor = MnTheme.backgroundColorScheme.primary,
+        topBar = {
+            MnTopAppBar(
+                actions = {
+                    Box(
+                        modifier = Modifier
+                            .size(40.dp)
+                            .noRippleClickable { },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        MnMediumIcon(
+                            resourceId = R.drawable.ic_null,
+                            tint = MnTheme.iconColorScheme.primary
+                        )
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        Column(
+            modifier = Modifier
+                .padding(innerPadding)
+                .padding(top = 119.dp)
+                .fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(25.dp)
+        ) {
+            CatRiveBox()
+            FocusBox()
+            StartButton()
+        }
+    }
+}
+
+@Composable
+private fun CatRiveBox() {
+    Box(
+        modifier = Modifier
+            .size(240.dp)
+            .background(MnTheme.backgroundColorScheme.secondary)
+    ) {
+        // TODO
+    }
+}
+
+@Composable
+private fun FocusBox(
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier.padding(vertical = MnSpacing.large),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(MnSpacing.medium)
+    ) {
+        CategoryBox()
+
+        Row(
+            modifier = Modifier.padding(horizontal = MnSpacing.twoXLarge),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(MnSpacing.medium)
+        ) {
+            TimeComponent(type = stringResource(R.string.focus), time = "25m")
+            TimeDivider()
+            TimeComponent(type = stringResource(R.string.rest), time = "10m")
+        }
+    }
+}
+
+@Composable
+private fun CategoryBox(
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .background(
+                color = MnTheme.backgroundColorScheme.secondary,
+                shape = RoundedCornerShape(MnRadius.xSmall)
+            )
+            .padding(
+                horizontal = MnSpacing.medium,
+                vertical = MnSpacing.small
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(MnSpacing.small)
+    ) {
+        MnMediumIcon(
+            resourceId = R.drawable.ic_null,
+            tint = MnTheme.iconColorScheme.primary
+        )
+        Text(
+            text = stringResource(R.string.focus),
+            style = MnTheme.typography.subBodySemiBold,
+            color = MnTheme.textColorScheme.tertiary
+        )
+    }
+}
+
+@Composable
+private fun TimeComponent(
+    type: String,
+    time: String,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier.padding(
+            vertical = MnSpacing.xSmall,
+            horizontal = MnSpacing.small
+        ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(MnSpacing.small)
+    ) {
+        CompositionLocalProvider(
+            LocalContentColor provides MnColor.Gray500
+        ) {
+            Text(
+                text = type,
+                style = MnTheme.typography.bodySemiBold
+            )
+            Text(
+                text = time,
+                style = MnTheme.typography.header3
+            )
+        }
+    }
+}
+
+@Composable
+private fun TimeDivider(modifier: Modifier = Modifier) {
+    Box(
+        modifier
+            .width(2.dp)
+            .height(20.dp)
+            .background(color = MnColor.Gray200, shape = RoundedCornerShape(MnRadius.xSmall))
+    )
+}
+
+@Composable
+private fun StartButton() {
+    Box(
+        modifier = Modifier
+            .size(88.dp)
+            .clip(RoundedCornerShape(MnRadius.max))
+            .background(color = MnTheme.backgroundColorScheme.accent1)
+            .clickable { },
+        contentAlignment = Alignment.Center
+    ) {
+        MnLargeIcon(
+            resourceId = R.drawable.ic_null,
+            tint = MnTheme.iconColorScheme.inverse
+        )
+    }
+}
+
+@Composable
+@Preview
+fun PomodoroStarterScreenPreview() {
+    PomodoroStarterScreen()
+}
+
+@Composable
+@Preview
+fun CatImagePreview() {
+    CatRiveBox()
+}
+
+@Composable
+@Preview(showBackground = true)
+fun FocusBoxPreview() {
+    FocusBox()
+}
+
+@Composable
+@Preview(showBackground = true)
+fun StartButtonPreview() {
+    StartButton()
+}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="focus">집중</string>
+    <string name="rest">휴식</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
     <string name="rest">휴식</string>
     <string name="tooltip_category_content">눌러서 카테고리를 변경할 수 있어요</string>
     <string name="tooltip_time_content">눌러서 시간을 조정할 수 있어요</string>
+    <string name="tooltip_rest_content">푹 쉬었나요?\n힘내서 다시 집중할까냥?</string>
 </resources>

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
 <resources>
     <string name="focus">집중</string>
     <string name="rest">휴식</string>
+    <string name="tooltip_category_content">눌러서 카테고리를 변경할 수 있어요</string>
+    <string name="tooltip_time_content">눌러서 시간을 조정할 수 있어요</string>
 </resources>


### PR DESCRIPTION
## 작업 내용

[figma link](https://www.figma.com/design/mRt5Ig9no20lXsWCAs2QqX/%EB%BD%80%EB%AA%A8%EB%83%A5-%ED%8C%80-%EB%94%94%EC%9E%90%EC%9D%B8-Main?node-id=761-19814&t=WgHdOAnXPLgw1Tak-4)

- UI 스켈레톤 수준 Component 위치 및 Tooltip만 구현
- ViewModel은 아직 연결을 안해둔 상태

<img src="https://github.com/user-attachments/assets/fcd9ce00-342b-4119-9cf3-56c29ca4c350" width = 50% />


3개의 섹션으로 나눠서 구현을 해봤어

```kotlin
Column(
    modifier = Modifier
        .padding(innerPadding)
        .padding(top = 119.dp)
        .fillMaxSize(),
    horizontalAlignment = Alignment.CenterHorizontally,
    verticalArrangement = Arrangement.spacedBy(25.dp)
) {
    CatRive()
    PomodoroDetailSetting(isNewUser)
    StartButton()
}
```

## 체크리스트
- [ ] 빌드 확인

## 동작 화면

### 전체적인 화면

<img width="1144" alt="image" src="https://github.com/user-attachments/assets/5bc61729-c42e-43f0-a691-bb367485665a">


### 툴팁 관련

> 내가 지금 구조를 툴팁 내부에서 dim을 갖고 있다 보니 연속된 툴팁이 있을때 배경의 dim이 완벽하게 유지가 힘들어서 구조 자체를 변경해야 하는 상황이라 우선 [디자이너 선생님들과 협의 살짝 진행](https://www.figma.com/design/mRt5Ig9no20lXsWCAs2QqX?node-id=761-19863#899692754)해보고 있어!..

https://github.com/user-attachments/assets/ff9148b3-456f-47b0-8356-cff33915c239


## 살려주세요

