### PR TITLE
[CAT-181] 집중 / 휴식시간 변경에 사용되는 Time Picker 구현

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -125,7 +125,8 @@ androidx-compose = [
     "androidx-compose-material",
     "androidx-compose-runtime",
     "androidx-compose-toolingPreview",
-    "androidx-lifecycle-runtime-compose"
+    "androidx-lifecycle-runtime-compose",
+    "kotlin-collections-immutable"
 ]
 
 androidx-compose-navigation = [

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelMinutePicker.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelMinutePicker.kt
@@ -1,0 +1,211 @@
+@file:OptIn(ExperimentalFoundationApi::class)
+
+package com.pomonyang.mohanyang.presentation.designsystem.picker
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.snapping.rememberSnapFlingBehavior
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
+import com.mohanyang.presentation.R
+import com.pomonyang.mohanyang.presentation.designsystem.icon.MnMediumIcon
+import com.pomonyang.mohanyang.presentation.designsystem.token.MnRadius
+import com.pomonyang.mohanyang.presentation.theme.MnTheme
+import com.pomonyang.mohanyang.presentation.util.dpToPx
+import com.pomonyang.mohanyang.presentation.util.pxToDp
+import kotlinx.collections.immutable.PersistentList
+import kotlinx.collections.immutable.toPersistentList
+
+@Composable
+fun MnWheelMinutePicker(
+    items: PersistentList<Int>,
+    halfDisplayCount: Int,
+    modifier: Modifier = Modifier,
+    textStyle: TextStyle = MnTheme.typography.header2,
+    mnWheelPickerColor: MnWheelPickerColor = MnWheelPickerDefaults.colors()
+) {
+    val scrollState = rememberLazyListState()
+    val itemHeightPx = MnWheelPickerDefaults.itemHeight.dpToPx()
+    val wheelHalfHeight by rememberUpdatedState(((2 * halfDisplayCount + 1) * itemHeightPx) / 2)
+    val brushColor = mnWheelPickerColor.fadeColor
+
+    Box(
+        modifier = modifier
+            .height((wheelHalfHeight * 2).pxToDp())
+            .fillMaxWidth()
+            .fadeEdge(brushColor)
+
+    ) {
+        CenterHighlightBox(
+            itemHeightPx = itemHeightPx,
+            highlightColor = MnTheme.backgroundColorScheme.secondary
+        )
+
+        WheelItemList(
+            items = items,
+            scrollState = scrollState,
+            itemHeightPx = itemHeightPx,
+            halfDisplayCount = halfDisplayCount,
+            textStyle = textStyle,
+            textColor = mnWheelPickerColor.textColor
+        )
+    }
+}
+
+@Composable
+private fun Modifier.fadeEdge(color: Color): Modifier {
+    val fadeEdgeBrushColor = remember {
+        arrayOf(
+            0f to color.copy(alpha = 0.95f),
+            0.25f to color.copy(alpha = 0.8f),
+            0.5f to Color.Transparent,
+            0.75f to color.copy(alpha = 0.8f),
+            1f to color.copy(alpha = 0.95f)
+        )
+    }
+    return this
+        .graphicsLayer(compositingStrategy = CompositingStrategy.Offscreen)
+        .drawWithCache {
+            val brush = Brush.verticalGradient(
+                colorStops = fadeEdgeBrushColor,
+                startY = 0f,
+                endY = size.height
+            )
+            onDrawWithContent {
+                drawContent()
+                drawRect(
+                    brush = brush,
+                    blendMode = BlendMode.DstOut
+                )
+            }
+        }
+}
+
+@Composable
+private fun BoxScope.CenterHighlightBox(
+    itemHeightPx: Float,
+    highlightColor: Color,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier
+            .fillMaxWidth()
+            .padding(horizontal = 83.dp)
+            .height(itemHeightPx.pxToDp())
+            .align(Alignment.Center)
+            .background(highlightColor, RoundedCornerShape(MnRadius.medium)),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        MnMediumIcon(resourceId = R.drawable.ic_null, modifier = Modifier.padding(start = 20.dp))
+    }
+}
+
+@Composable
+private fun BoxScope.WheelItemList(
+    items: PersistentList<Int>,
+    scrollState: LazyListState,
+    itemHeightPx: Float,
+    halfDisplayCount: Int,
+    textStyle: TextStyle,
+    textColor: Color
+) {
+    LazyColumn(
+        modifier = Modifier
+            .matchParentSize()
+            .zIndex(1f),
+        contentPadding = PaddingValues(vertical = itemHeightPx.pxToDp() * halfDisplayCount),
+        state = scrollState,
+        flingBehavior = rememberSnapFlingBehavior(scrollState)
+    ) {
+        itemsIndexed(
+            items = items,
+            key = { _, item -> item.toString() }
+        ) { index, item ->
+            val isCentralItem by remember {
+                derivedStateOf {
+                    val layoutInfo = scrollState.layoutInfo
+                    val visibleItemsInfo = layoutInfo.visibleItemsInfo
+
+                    if (visibleItemsInfo.isNotEmpty()) {
+                        val viewportCenter = (layoutInfo.viewportStartOffset + layoutInfo.viewportEndOffset) / 2
+                        val itemInfo = visibleItemsInfo.find { itemInfo ->
+                            val itemCenter = (itemInfo.offset + itemInfo.size / 2)
+                            itemCenter in (viewportCenter - itemInfo.size / 2)..(viewportCenter + itemInfo.size / 2)
+                        }
+                        itemInfo?.index == index
+                    } else {
+                        false
+                    }
+                }
+            }
+
+            val scale by animateFloatAsState(
+                targetValue = if (isCentralItem) 1.3f else 1f,
+                animationSpec = tween(durationMillis = 100),
+                label = "scaleAnimation"
+            )
+
+            Box(
+                modifier = Modifier
+                    .height(itemHeightPx.pxToDp())
+                    .padding(start = 22.dp)
+                    .fillMaxWidth()
+                    .scale(scale),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = "$item:00",
+                    style = textStyle,
+                    color = textColor
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun MnWheelPickerPreview() {
+    MnTheme {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(MnTheme.backgroundColorScheme.primary)
+        )
+        MnWheelMinutePicker(
+            items = (5..60 step 5).toPersistentList(),
+            halfDisplayCount = 3
+        )
+    }
+}

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelMinutePicker.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelMinutePicker.kt
@@ -80,7 +80,8 @@ fun MnWheelMinutePicker(
             itemHeightPx = itemHeightPx,
             halfDisplayCount = halfDisplayCount,
             textStyle = textStyle,
-            textColor = mnWheelPickerColor.textColor
+            selectedTextColor = mnWheelPickerColor.selectedTextColor,
+            unSelectedTextColor = mnWheelPickerColor.unSelectedTextColor
         )
     }
 }
@@ -90,9 +91,9 @@ private fun Modifier.fadeEdge(color: Color): Modifier {
     val fadeEdgeBrushColor = remember {
         arrayOf(
             0f to color.copy(alpha = 0.95f),
-            0.25f to color.copy(alpha = 0.8f),
+            0.25f to color.copy(alpha = 0.3f),
             0.5f to Color.Transparent,
-            0.75f to color.copy(alpha = 0.8f),
+            0.75f to color.copy(alpha = 0.3f),
             1f to color.copy(alpha = 0.95f)
         )
     }
@@ -139,7 +140,8 @@ private fun BoxScope.WheelItemList(
     itemHeightPx: Float,
     halfDisplayCount: Int,
     textStyle: TextStyle,
-    textColor: Color,
+    selectedTextColor: Color,
+    unSelectedTextColor: Color,
     modifier: Modifier = Modifier
 ) {
     LazyColumn(
@@ -189,7 +191,7 @@ private fun BoxScope.WheelItemList(
                 Text(
                     text = "$item:00",
                     style = textStyle,
-                    color = textColor
+                    color = if (isCentralItem) selectedTextColor else unSelectedTextColor
                 )
             }
         }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelMinutePicker.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelMinutePicker.kt
@@ -139,10 +139,11 @@ private fun BoxScope.WheelItemList(
     itemHeightPx: Float,
     halfDisplayCount: Int,
     textStyle: TextStyle,
-    textColor: Color
+    textColor: Color,
+    modifier: Modifier = Modifier
 ) {
     LazyColumn(
-        modifier = Modifier
+        modifier = modifier
             .matchParentSize()
             .zIndex(1f),
         contentPadding = PaddingValues(vertical = itemHeightPx.pxToDp() * halfDisplayCount),

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelMinutePicker.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelMinutePicker.kt
@@ -50,12 +50,13 @@ import kotlinx.collections.immutable.toPersistentList
 @Composable
 fun MnWheelMinutePicker(
     items: PersistentList<Int>,
+    initialItem: Int,
     halfDisplayCount: Int,
     modifier: Modifier = Modifier,
     textStyle: TextStyle = MnTheme.typography.header2,
     mnWheelPickerColor: MnWheelPickerColor = MnWheelPickerDefaults.colors()
 ) {
-    val scrollState = rememberLazyListState()
+    val scrollState = rememberLazyListState(items.indexOf(initialItem))
     val itemHeightPx = MnWheelPickerDefaults.itemHeight.dpToPx()
     val wheelHalfHeight by rememberUpdatedState(((2 * halfDisplayCount + 1) * itemHeightPx) / 2)
     val brushColor = mnWheelPickerColor.fadeColor
@@ -205,7 +206,8 @@ fun MnWheelPickerPreview() {
         )
         MnWheelMinutePicker(
             items = (5..60 step 5).toPersistentList(),
-            halfDisplayCount = 3
+            halfDisplayCount = 3,
+            initialItem = 25
         )
     }
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelMinutePicker.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelMinutePicker.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -121,8 +122,7 @@ private fun BoxScope.CenterHighlightBox(
 ) {
     Box(
         modifier
-            .fillMaxWidth()
-            .padding(horizontal = 83.dp)
+            .width(200.dp)
             .height(itemHeightPx.pxToDp())
             .align(Alignment.Center)
             .background(highlightColor, RoundedCornerShape(MnRadius.medium)),
@@ -173,7 +173,7 @@ private fun BoxScope.WheelItemList(
             }
 
             val scale by animateFloatAsState(
-                targetValue = if (isCentralItem) 1.3f else 1f,
+                targetValue = if (isCentralItem) 1.2f else 1f,
                 animationSpec = tween(durationMillis = 100),
                 label = "scaleAnimation"
             )
@@ -181,7 +181,7 @@ private fun BoxScope.WheelItemList(
             Box(
                 modifier = Modifier
                     .height(itemHeightPx.pxToDp())
-                    .padding(start = 22.dp)
+                    .padding(start = 24.dp)
                     .fillMaxWidth()
                     .scale(scale),
                 contentAlignment = Alignment.Center

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelPickerDefaults.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelPickerDefaults.kt
@@ -1,0 +1,27 @@
+package com.pomonyang.mohanyang.presentation.designsystem.picker
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.pomonyang.mohanyang.presentation.theme.MnTheme
+
+object MnWheelPickerDefaults {
+    val itemHeight: Dp = 80.dp
+
+    @Composable
+    fun colors(
+        fadeColor: Color = MnTheme.backgroundColorScheme.inverse,
+        textColor: Color = MnTheme.textColorScheme.primary
+    ) = MnWheelPickerColor(
+        fadeColor = fadeColor,
+        textColor = textColor
+    )
+}
+
+@Stable
+data class MnWheelPickerColor(
+    val fadeColor: Color,
+    val textColor: Color
+)

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelPickerDefaults.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelPickerDefaults.kt
@@ -13,15 +13,18 @@ object MnWheelPickerDefaults {
     @Composable
     fun colors(
         fadeColor: Color = MnTheme.backgroundColorScheme.inverse,
-        textColor: Color = MnTheme.textColorScheme.primary
+        selectedTextColor: Color = MnTheme.textColorScheme.primary,
+        unSelectedTextColor: Color = MnTheme.textColorScheme.disabled
     ) = MnWheelPickerColor(
         fadeColor = fadeColor,
-        textColor = textColor
+        selectedTextColor = selectedTextColor,
+        unSelectedTextColor = unSelectedTextColor
     )
 }
 
 @Stable
 data class MnWheelPickerColor(
     val fadeColor: Color,
-    val textColor: Color
+    val selectedTextColor: Color,
+    val unSelectedTextColor: Color
 )

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/token/MnTypography.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/token/MnTypography.kt
@@ -61,7 +61,6 @@ data class MnTypography(
         fontSize = 34.sp,
         lineHeight = 41.sp,
         lineHeightStyle = setDefaultLineHeight(),
-
         letterSpacing = (-0.02).em
     ),
     val header3: TextStyle = TextStyle(


### PR DESCRIPTION
## 작업 내용

[figma](https://www.figma.com/design/mRt5Ig9no20lXsWCAs2QqX/%EB%BD%80%EB%AA%A8%EB%83%A5-%ED%8C%80-%EB%94%94%EC%9E%90%EC%9D%B8-Main?node-id=1460-27771&t=s3F2IaJi9JVUiiXG-4)

- 05분 ~ 60분까지 5분 단위로 선택 가능한 휠피커 구현
- figma의 가이드를 완벽하게 따라기지는 못한 상황
  - gradient나 정중앙 정렬이 아닌 UI인데 피커처럼 돌아가는 형태에서는 좀 힘들어서 디자이너와 [타협](https://discord.com/channels/1259883776474087638/1263826433969491998/1271474198581350442)

## 체크리스트
- [ ] 빌드 확인
- [ ] 잘 돌아가는지 확인

## 동작 화면

https://github.com/user-attachments/assets/b299a87a-e55c-4b65-9d31-12ede3b7d3c3

## 살려주세요

이거 좀 쉽지 않네

