### PR TITLE
[CAT-135] 로컬 집중 알림 기능 구현

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
 
     <application

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,8 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+
 
     <application
         android:name="com.pomonyang.mohanyang.MohaNyangApplication"
@@ -26,6 +28,8 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <receiver android:name=".notification.LocalNotificationReceiver" />
+        <service android:name=".notification.FocusNotificationService" />
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
-
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
 
     <application
         android:name="com.pomonyang.mohanyang.MohaNyangApplication"

--- a/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.pomonyang.mohanyang
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -21,13 +23,13 @@ import com.pomonyang.mohanyang.data.remote.util.NetworkMonitor
 import com.pomonyang.mohanyang.data.repository.pomodoro.PomodoroSettingRepository
 import com.pomonyang.mohanyang.data.repository.user.UserRepository
 import com.pomonyang.mohanyang.domain.usecase.GetTokenByDeviceIdUseCase
+import com.pomonyang.mohanyang.notification.FocusNotificationService
+import com.pomonyang.mohanyang.notification.util.createNotificationChannel
+import com.pomonyang.mohanyang.notification.util.isNotificationGranted
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButton
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonColorType
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonStyles
 import com.pomonyang.mohanyang.presentation.designsystem.dialog.MnDialog
-import com.pomonyang.mohanyang.notification.FocusNotificationService
-import com.pomonyang.mohanyang.notification.util.createNotificationChannel
-import com.pomonyang.mohanyang.notification.util.isNotificationGranted
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.ui.MohaNyangApp
 import com.pomonyang.mohanyang.ui.rememberMohaNyangAppState
@@ -55,6 +57,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         createNotificationChannel()
+        handleSplashScreen()
 
         enableEdgeToEdge()
         setContent {

--- a/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
@@ -27,6 +27,7 @@ import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonS
 import com.pomonyang.mohanyang.presentation.designsystem.dialog.MnDialog
 import com.pomonyang.mohanyang.notification.FocusNotificationService
 import com.pomonyang.mohanyang.notification.util.createNotificationChannel
+import com.pomonyang.mohanyang.notification.util.isNotificationGranted
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.ui.MohaNyangApp
 import com.pomonyang.mohanyang.ui.rememberMohaNyangAppState
@@ -118,11 +119,11 @@ class MainActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
-        stopService(Intent(this, FocusNotificationService::class.java))
+        if (isNotificationGranted()) stopService(Intent(this, FocusNotificationService::class.java))
     }
 
     override fun onPause() {
         super.onPause()
-        startService(Intent(this, FocusNotificationService::class.java))
+        if (isNotificationGranted()) startService(Intent(this, FocusNotificationService::class.java))
     }
 }

--- a/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.pomonyang.mohanyang
 
-import android.app.Activity
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -26,6 +25,8 @@ import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButton
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonColorType
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonStyles
 import com.pomonyang.mohanyang.presentation.designsystem.dialog.MnDialog
+import com.pomonyang.mohanyang.notification.FocusNotificationService
+import com.pomonyang.mohanyang.notification.util.createNotificationChannel
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.ui.MohaNyangApp
 import com.pomonyang.mohanyang.ui.rememberMohaNyangAppState
@@ -51,7 +52,9 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        handleSplashScreen()
+
+        createNotificationChannel()
+
         enableEdgeToEdge()
         setContent {
             val coroutineScope = rememberCoroutineScope()
@@ -111,5 +114,15 @@ class MainActivity : ComponentActivity() {
 
     companion object {
         private const val SPLASH_DELAY = 2000L
+    }
+
+    override fun onResume() {
+        super.onResume()
+        stopService(Intent(this, FocusNotificationService::class.java))
+    }
+
+    override fun onPause() {
+        super.onPause()
+        startService(Intent(this, FocusNotificationService::class.java))
     }
 }

--- a/app/src/main/java/com/pomonyang/mohanyang/di/ManagerModule.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/di/ManagerModule.kt
@@ -1,0 +1,23 @@
+package com.pomonyang.mohanyang.di
+
+import android.app.AlarmManager
+import android.content.Context
+import com.pomonyang.mohanyang.notification.MnAlarmManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object ManagerModule {
+    @Provides
+    internal fun provideMnAlarmManager(
+        @ApplicationContext context: Context
+    ): MnAlarmManager {
+        val alarmManager =
+            context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        return MnAlarmManager(context, alarmManager)
+    }
+}

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/FocusNotificationService.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/FocusNotificationService.kt
@@ -5,8 +5,9 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
+import com.pomonyang.mohanyang.R
 import com.pomonyang.mohanyang.data.local.device.util.lockScreenState
-import com.pomonyang.mohanyang.presentation.designsystem.token.MnRadius.max
+import com.pomonyang.mohanyang.domain.model.cat.CatType
 import dagger.hilt.android.AndroidEntryPoint
 import java.time.LocalTime
 import javax.inject.Inject
@@ -22,6 +23,8 @@ import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class FocusNotificationService : Service() {
+
+    val selectedCatType = CatType.CHEESE
 
     private val serviceScope = CoroutineScope(Dispatchers.Default)
     private var focusNotificationJob: Job? = null
@@ -74,13 +77,21 @@ class FocusNotificationService : Service() {
         focusNotificationJob = serviceScope.launch {
             // 10초 후 첫 알림 전송
             delay(FIRST_DELAY)
-            mnAlarmManager.createAlarm(LocalTime.now(), title = "첫 번째 알림", message = "10초 후 첫 번째 알림이 도착했습니다.").also {
+            mnAlarmManager.createAlarm(
+                LocalTime.now(),
+                title = applicationContext.getString(R.string.app_name),
+                message = "10초 : ${selectedCatType.pushContent}"
+            ).also {
                 focusNotifications.add(it)
             }
             // 30초마다 반복 알림 전송
             repeat(MAX_NOTIFICATION_COUNT) {
                 delay(REPEAT_DELAY)
-                mnAlarmManager.createAlarm(LocalTime.now(), title = "반복 알림", message = "${(REPEAT_DELAY / 1000).toInt()}}초마다 반복 알림이 도착했습니다. (${it + 1}/$max)").also { alarm ->
+                mnAlarmManager.createAlarm(
+                    LocalTime.now(),
+                    title = applicationContext.getString(R.string.app_name),
+                    message = "${(REPEAT_DELAY / 1000).toInt()}초 :  ${selectedCatType.pushContent}"
+                ).also { alarm ->
                     focusNotifications.add(alarm)
                 }
             }
@@ -90,7 +101,9 @@ class FocusNotificationService : Service() {
 
     companion object {
         private const val MAX_NOTIFICATION_COUNT = 10
+
+        // TODO 최대 수가 없다고 픽스나면 while true로 변경하기
         private const val FIRST_DELAY = 10_000L
-        private const val REPEAT_DELAY = 3_000L
+        private const val REPEAT_DELAY = 30_000L
     }
 }

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/FocusNotificationService.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/FocusNotificationService.kt
@@ -1,0 +1,96 @@
+package com.pomonyang.mohanyang.notification
+
+import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import com.pomonyang.mohanyang.data.local.device.util.lockScreenState
+import com.pomonyang.mohanyang.presentation.designsystem.token.MnRadius.max
+import dagger.hilt.android.AndroidEntryPoint
+import java.time.LocalTime
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+@AndroidEntryPoint
+class FocusNotificationService : Service() {
+
+    private val serviceScope = CoroutineScope(Dispatchers.Default)
+    private var focusNotificationJob: Job? = null
+    private val focusNotifications = ArrayList<PendingIntent>()
+
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    private val isLocked: Flow<Boolean> = this.lockScreenState()
+
+    @Inject
+    lateinit var mnAlarmManager: MnAlarmManager
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        observeLockScreen()
+        startFocusNotify()
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    override fun onTaskRemoved(rootIntent: Intent?) {
+        super.onTaskRemoved(rootIntent)
+        stopNotify()
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onDestroy() {
+        super.onDestroy()
+        stopNotify()
+    }
+
+    private fun observeLockScreen() {
+        isLocked.onEach { isLocked ->
+            if (isLocked) {
+                stopNotify()
+            }
+        }.launchIn(serviceScope)
+    }
+
+    private fun stopNotify() {
+        focusNotifications.run {
+            forEach { mnAlarmManager.cancelAlarm(it) }
+            clear()
+        }
+        serviceScope.cancel()
+        focusNotificationJob?.cancel()
+        focusNotificationJob = null
+        stopSelf()
+    }
+
+    private fun startFocusNotify() {
+        focusNotificationJob = serviceScope.launch {
+            // 10초 후 첫 알림 전송
+            delay(FIRST_DELAY)
+            mnAlarmManager.createAlarm(LocalTime.now(), title = "첫 번째 알림", message = "10초 후 첫 번째 알림이 도착했습니다.").also {
+                focusNotifications.add(it)
+            }
+            // 30초마다 반복 알림 전송
+            repeat(MAX_NOTIFICATION_COUNT) {
+                delay(REPEAT_DELAY)
+                mnAlarmManager.createAlarm(LocalTime.now(), title = "반복 알림", message = "${(REPEAT_DELAY / 1000).toInt()}}초마다 반복 알림이 도착했습니다. (${it + 1}/$max)").also { alarm ->
+                    focusNotifications.add(alarm)
+                }
+            }
+            stopSelf()
+        }
+    }
+
+    companion object {
+        private const val MAX_NOTIFICATION_COUNT = 10
+        private const val FIRST_DELAY = 10_000L
+        private const val REPEAT_DELAY = 3_000L
+    }
+}

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/FocusNotificationService.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/FocusNotificationService.kt
@@ -5,6 +5,7 @@ import android.app.PendingIntent
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
+import com.pomonyang.mohanyang.BuildConfig
 import com.pomonyang.mohanyang.R
 import com.pomonyang.mohanyang.data.local.device.util.lockScreenState
 import com.pomonyang.mohanyang.domain.model.cat.CatType
@@ -29,7 +30,7 @@ class FocusNotificationService : Service() {
 
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     private var focusNotificationJob: Job? = null
-    private val focusNotifications = ArrayList<PendingIntent>()
+    private val focusNotifications = mutableListOf<PendingIntent>()
 
     @SuppressLint("UnspecifiedRegisterReceiverFlag")
     private val isLocked: Flow<Boolean> = this.lockScreenState()
@@ -39,7 +40,6 @@ class FocusNotificationService : Service() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         observeLockScreen()
-
         startFocusNotify()
         return super.onStartCommand(intent, flags, startId)
     }
@@ -104,8 +104,8 @@ class FocusNotificationService : Service() {
     companion object {
         // TODO 최대 수가 없다고 픽스나면 while true로 변경하기
         private const val MAX_NOTIFICATION_COUNT = 10
-        private const val FIRST_DELAY = 10_000L
-        private const val REPEAT_DELAY = 30_000L
-        private const val LAST_ALARM_DISPLAY_DURATION = REPEAT_DELAY * 3 // TODO 임시로 임의 지정
+        private val FIRST_DELAY = if (BuildConfig.DEBUG) 2_000L else 10_000L
+        private val REPEAT_DELAY = if (BuildConfig.DEBUG) 5_000L else 30_000L
+        private val LAST_ALARM_DISPLAY_DURATION = REPEAT_DELAY * 3 // TODO 임시로 임의 지정
     }
 }

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/LocalNotificationReceiver.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/LocalNotificationReceiver.kt
@@ -1,0 +1,59 @@
+package com.pomonyang.mohanyang.notification
+
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import com.pomonyang.mohanyang.MainActivity
+import com.pomonyang.mohanyang.R
+import com.pomonyang.mohanyang.notification.util.defaultNotification
+import com.pomonyang.mohanyang.notification.util.summaryNotification
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class LocalNotificationReceiver @Inject constructor() : BroadcastReceiver() {
+
+    override fun onReceive(context: Context?, intent: Intent?) {
+        if (intent == null || context == null) return
+
+        val notificationId = intent.getIntExtra(context.getString(R.string.local_notification_id), 0)
+        val title = intent.getStringExtra(context.getString(R.string.local_notification_title)) ?: ""
+        val message = intent.getStringExtra(context.getString(R.string.local_notification_message)) ?: ""
+
+        val notificationIntent = Intent(context, MainActivity::class.java)
+        val pendingIntent =
+            PendingIntent.getActivity(
+                context,
+                notificationId,
+                notificationIntent,
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+
+        val notification =
+            context.defaultNotification(pendingIntent)
+                .setContentTitle(title)
+                .setContentText(message)
+                .setFullScreenIntent(pendingIntent, true)
+                .build()
+
+        val summaryNotification =
+            context.summaryNotification(pendingIntent)
+                .setContentTitle(title)
+                .setContentText(message)
+                .build()
+
+        val notificationManager =
+            context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+
+        notificationManager.apply {
+            notify(notificationId, notification)
+            notify(SUMMARY_ID, summaryNotification)
+        }
+    }
+
+    companion object {
+        private const val SUMMARY_ID = 0
+    }
+}

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/LocalNotificationReceiver.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/LocalNotificationReceiver.kt
@@ -8,6 +8,7 @@ import android.content.Intent
 import com.pomonyang.mohanyang.MainActivity
 import com.pomonyang.mohanyang.R
 import com.pomonyang.mohanyang.notification.util.defaultNotification
+import com.pomonyang.mohanyang.notification.util.isNotificationGranted
 import com.pomonyang.mohanyang.notification.util.summaryNotification
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -17,6 +18,8 @@ class LocalNotificationReceiver @Inject constructor() : BroadcastReceiver() {
 
     override fun onReceive(context: Context?, intent: Intent?) {
         if (intent == null || context == null) return
+
+        if (!context.isNotificationGranted()) return
 
         val notificationId = intent.getIntExtra(context.getString(R.string.local_notification_id), 0)
         val title = intent.getStringExtra(context.getString(R.string.local_notification_title)) ?: ""

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/LocalNotificationReceiver.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/LocalNotificationReceiver.kt
@@ -35,7 +35,6 @@ class LocalNotificationReceiver @Inject constructor() : BroadcastReceiver() {
             context.defaultNotification(pendingIntent)
                 .setContentTitle(title)
                 .setContentText(message)
-                .setFullScreenIntent(pendingIntent, true)
                 .build()
 
         val summaryNotification =

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/MnAlarmManager.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/MnAlarmManager.kt
@@ -1,0 +1,55 @@
+package com.pomonyang.mohanyang.notification
+
+import android.annotation.SuppressLint
+import android.app.AlarmManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import com.pomonyang.mohanyang.R
+import com.pomonyang.mohanyang.notification.util.getTriggerTimeInMillis
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.time.LocalTime
+import java.util.*
+import javax.inject.Inject
+
+class MnAlarmManager @Inject constructor(
+    @ApplicationContext private val applicationContext: Context,
+    private val alarmManager: AlarmManager
+) {
+    @SuppressLint("ScheduleExactAlarm")
+    fun createAlarm(
+        scheduleTime: LocalTime,
+        id: Int = UUID.randomUUID().hashCode(),
+        title: String = "",
+        message: String = ""
+    ): PendingIntent =
+        with(applicationContext) {
+            val intent =
+                Intent(this, LocalNotificationReceiver::class.java).apply {
+                    putExtra(getString(R.string.local_notification_id), id)
+                    putExtra(getString(R.string.local_notification_title), title)
+                    putExtra(getString(R.string.local_notification_message), message)
+                }
+
+            val pendingIntent =
+                PendingIntent.getBroadcast(
+                    this,
+                    id,
+                    intent,
+                    PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+                )
+
+            val triggerTime = getTriggerTimeInMillis(scheduleTime)
+
+            alarmManager.setExactAndAllowWhileIdle(
+                AlarmManager.RTC_WAKEUP,
+                triggerTime,
+                pendingIntent
+            )
+            return pendingIntent
+        }
+
+    fun cancelAlarm(pendingIntent: PendingIntent) {
+        alarmManager.cancel(pendingIntent)
+    }
+}

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/util/NotificationUtils.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/util/NotificationUtils.kt
@@ -1,0 +1,53 @@
+package com.pomonyang.mohanyang.notification.util
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Context.NOTIFICATION_SERVICE
+import androidx.core.app.NotificationCompat
+import com.pomonyang.mohanyang.R
+import java.time.LocalDate
+import java.time.LocalTime
+import java.time.ZoneId
+
+fun Context.createNotificationChannel() {
+    val notificationManager =
+        applicationContext.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+
+    val channelId = applicationContext.getString(R.string.channel_id)
+    val channelName = applicationContext.getString(R.string.channel_name)
+
+    val channel =
+        NotificationChannel(
+            channelId,
+            channelName,
+            NotificationManager.IMPORTANCE_HIGH
+        )
+    notificationManager.createNotificationChannel(channel)
+}
+
+fun Context.defaultNotification(
+    pendingIntent: PendingIntent? = null
+): NotificationCompat.Builder = NotificationCompat.Builder(
+    this,
+    getString(R.string.channel_id)
+)
+    .setContentIntent(pendingIntent)
+    .setSmallIcon(com.mohanyang.presentation.R.drawable.ic_null)
+    .setPriority(NotificationCompat.PRIORITY_HIGH)
+    .setAutoCancel(true)
+    .setOnlyAlertOnce(true)
+    .setGroup(getString(R.string.channel_group_name))
+
+fun Context.summaryNotification(pendingIntent: PendingIntent? = null): NotificationCompat.Builder = this.defaultNotification(pendingIntent)
+    .setGroupSummary(true)
+
+fun getTriggerTimeInMillis(time: LocalTime): Long {
+    val now = LocalDate.now()
+    val dateTime = time.atDate(now)
+    return dateTime
+        .atZone(ZoneId.systemDefault())
+        .toInstant()
+        .toEpochMilli()
+}

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/util/NotificationUtils.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/util/NotificationUtils.kt
@@ -5,7 +5,10 @@ import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Context.NOTIFICATION_SERVICE
+import android.content.pm.PackageManager
+import android.os.Build
 import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
 import com.pomonyang.mohanyang.R
 import java.time.LocalDate
 import java.time.LocalTime
@@ -53,3 +56,7 @@ fun getTriggerTimeInMillis(time: LocalTime): Long {
         .toInstant()
         .toEpochMilli()
 }
+
+fun Context.isNotificationGranted(): Boolean = (
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && PackageManager.PERMISSION_DENIED == ContextCompat.checkSelfPermission(this, android.Manifest.permission.POST_NOTIFICATIONS)
+    )

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/util/NotificationUtils.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/util/NotificationUtils.kt
@@ -38,6 +38,8 @@ fun Context.defaultNotification(
     .setPriority(NotificationCompat.PRIORITY_HIGH)
     .setAutoCancel(true)
     .setOnlyAlertOnce(true)
+    .setFullScreenIntent(pendingIntent, true)
+    .setCategory(NotificationCompat.CATEGORY_MESSAGE)
     .setGroup(getString(R.string.channel_group_name))
 
 fun Context.summaryNotification(pendingIntent: PendingIntent? = null): NotificationCompat.Builder = this.defaultNotification(pendingIntent)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,10 @@
 <resources>
     <string name="app_name">moha-nyang</string>
+    <string name="channel_id">moha-nyang-channel</string>
+    <string name="channel_name">moha-nyang</string>
+    <string name="channel_group_name">moha-nyang-pomodoro</string>
+    <string name="local_notification_id">local_notification_id</string>
+    <string name="local_notification_title">local_notification_title</string>
+    <string name="local_notification_message">local_notification_message</string>
+
 </resources>

--- a/data/src/main/java/com/pomonyang/mohanyang/data/local/device/util/LockScreenUtils.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/local/device/util/LockScreenUtils.kt
@@ -1,0 +1,40 @@
+package com.pomonyang.mohanyang.data.local.device.util
+
+import android.content.Context
+import android.content.Context.RECEIVER_EXPORTED
+import android.content.Context.RECEIVER_NOT_EXPORTED
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+import com.pomonyang.mohanyang.data.local.device.receiver.LockScreenBroadcastReceiver
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.callbackFlow
+
+fun Context.lockScreenState() = callbackFlow {
+    val lockScreenReceiver = LockScreenBroadcastReceiver { isLocked ->
+        trySend(isLocked)
+    }
+
+    val screenEventIntentFilter = IntentFilter().apply {
+        addAction(Intent.ACTION_SCREEN_ON)
+        addAction(Intent.ACTION_SCREEN_OFF)
+    }
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        applicationContext.registerReceiver(
+            lockScreenReceiver,
+            screenEventIntentFilter,
+            RECEIVER_NOT_EXPORTED
+        )
+    } else {
+        applicationContext.registerReceiver(
+            lockScreenReceiver,
+            screenEventIntentFilter,
+            RECEIVER_EXPORTED
+        )
+    }
+
+    awaitClose {
+        applicationContext.unregisterReceiver(lockScreenReceiver)
+    }
+}

--- a/data/src/main/java/com/pomonyang/mohanyang/data/local/device/util/LockScreenUtils.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/local/device/util/LockScreenUtils.kt
@@ -9,6 +9,7 @@ import android.os.Build
 import com.pomonyang.mohanyang.data.local.device.receiver.LockScreenBroadcastReceiver
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
 
 fun Context.lockScreenState() = callbackFlow {
     val lockScreenReceiver = LockScreenBroadcastReceiver { isLocked ->
@@ -37,4 +38,4 @@ fun Context.lockScreenState() = callbackFlow {
     awaitClose {
         applicationContext.unregisterReceiver(lockScreenReceiver)
     }
-}
+}.distinctUntilChanged()


### PR DESCRIPTION
> 사용자의 pushEnable 상태, 고양이 선택 값에 따라 알림 기능 구현, 메세지 수정은 이후 PR 로 올릴게

## 작업 내용
- 앱 background 전환 시 집중 알림 기능 보내는 기능 구현
- 첫번째 10초/ 이후 30초 간격으로 알림 
- 앱 재전환 시 , 화면 off 시 알림 정지 기능 구현

## 체크리스트
- [x] 빌드 확인
- [x] 알림 허용되어 있는 지 확인 후 테스트 (알림 허용 권한 기능 추가 안함)
- [x] 방해금지 모드 사용 시 메세지 받게 되어 있는 지 확인
- [x] 앱 background -> resume 후 알림 멈추는 지 확인
- [x] 화면 Off 후 알림 멈추는 지 확인

## 동작 화면

https://github.com/user-attachments/assets/39949ae1-2ad9-43f3-84fb-76a06eb2b1c7

> 30초 간격인데 답답해서 10초로 녹화했어..ㅎ 

## 살려주세요
알림 서비스 호출한 다음 바로 10초뒤에 울려야 하는데 호출까지 한 2~3초 딜레이가 생기는거 같아 음..
서비스 시작 이후로는 딜레이 없음
