### PR TITLE
[CAT-218] popupPositionProvider를 사용하는 tooltip 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         <activity
             android:name="com.pomonyang.mohanyang.MainActivity"
             android:exported="true"
-            android:theme="@style/Theme.Mohanyang.Splash">
+            android:theme="@style/Theme.Mohanyang.Splash"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/OnboardingNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/OnboardingNavigator.kt
@@ -23,7 +23,8 @@ internal data object OnboardingSelectCat
 
 @Serializable
 internal data class OnboardingNamingCat(
-    val catNo: Int
+    val catNo: Int,
+    val catName: String?
 )
 
 fun NavGraphBuilder.onboardingScreen(
@@ -44,17 +45,20 @@ fun NavGraphBuilder.onboardingScreen(
         composable<OnboardingSelectCat> {
             OnboardingSelectCatRoute(
                 onBackClick = { navHostController.popBackStack() },
-                onNavToNaming = { catNo ->
-                    navHostController.navigate(OnboardingNamingCat(catNo = catNo))
+                onNavToNaming = { catNo, catName ->
+                    navHostController.navigate(OnboardingNamingCat(catNo = catNo, catName = catName))
                 }
             )
         }
 
         composable<OnboardingNamingCat> { navBackStackEntry ->
-            val catNo = navBackStackEntry.toRoute<OnboardingNamingCat>().catNo
+            val namingCat = navBackStackEntry.toRoute<OnboardingNamingCat>()
+            val catNo = namingCat.catNo
+            val catName = namingCat.catName
 
             OnboardingNamingCatRoute(
                 catNo = catNo,
+                catName = catName,
                 onBackClick = { navHostController.popBackStack() },
                 onNavToHome = {
                     navHostController.navigate(

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/naming/OnboardingNamingCatScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/naming/OnboardingNamingCatScreen.kt
@@ -152,16 +152,15 @@ fun OnboardingNamingCatScreen(
 }
 
 @Composable
-fun CatRive(modifier: Modifier = Modifier) {
+private fun CatRive(modifier: Modifier = Modifier) {
     Box(
         modifier = modifier
             .fillMaxWidth()
             .height(240.dp)
             .background(MnTheme.backgroundColorScheme.secondary)
             .tooltip(
-                stringResource(id = R.string.naming_cat_tooltip),
-                showOverlay = false,
-                enabled = false // TODO 툴팁 적용시 포커스 불가문제 해결
+                content = stringResource(id = R.string.naming_cat_tooltip),
+                enabled = true // TODO 툴팁 적용시 포커스 불가문제 해결
 
             ),
         contentAlignment = Alignment.Center

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/naming/OnboardingNamingCatScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/naming/OnboardingNamingCatScreen.kt
@@ -45,6 +45,7 @@ import com.pomonyang.mohanyang.presentation.util.noRippleClickable
 @Composable
 fun OnboardingNamingCatRoute(
     catNo: Int,
+    catName: String?,
     onBackClick: () -> Unit,
     onNavToHome: () -> Unit,
     modifier: Modifier = Modifier,
@@ -60,6 +61,7 @@ fun OnboardingNamingCatRoute(
 
     OnboardingNamingCatScreen(
         catNo = catNo,
+        catName = catName,
         onAction = onboardingNamingCatViewModel::handleEvent,
         onBackClick = onBackClick,
         modifier = modifier
@@ -69,6 +71,7 @@ fun OnboardingNamingCatRoute(
 @Composable
 fun OnboardingNamingCatScreen(
     catNo: Int,
+    catName: String?,
     onAction: (NamingEvent) -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -77,7 +80,7 @@ fun OnboardingNamingCatScreen(
     val keyboardController = LocalSoftwareKeyboardController.current
     val listState = rememberLazyListState()
 
-    var name by rememberSaveable { mutableStateOf("") }
+    var name by rememberSaveable { mutableStateOf(catName ?: "") }
     val catNameValidator = remember { CatNameVerifier() }
     var nameValidationResult by remember {
         mutableStateOf(ValidationResult(true))
@@ -158,11 +161,7 @@ private fun CatRive(modifier: Modifier = Modifier) {
             .fillMaxWidth()
             .height(240.dp)
             .background(MnTheme.backgroundColorScheme.secondary)
-            .tooltip(
-                content = stringResource(id = R.string.naming_cat_tooltip),
-                enabled = true // TODO 툴팁 적용시 포커스 불가문제 해결
-
-            ),
+            .tooltip(content = stringResource(id = R.string.naming_cat_tooltip)),
         contentAlignment = Alignment.Center
     ) {
         Text(text = "image")
@@ -174,7 +173,8 @@ private fun CatRive(modifier: Modifier = Modifier) {
 fun PreviewOnboardingNamingCatScreen() {
     OnboardingNamingCatScreen(
         catNo = 1,
-        onBackClick = {},
-        onAction = { _ -> }
+        catName = "삼색이",
+        onAction = { _ -> },
+        onBackClick = {}
     )
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/select/OnboardingSelectCatScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/select/OnboardingSelectCatScreen.kt
@@ -52,7 +52,7 @@ import kotlinx.collections.immutable.toPersistentList
 @Composable
 fun OnboardingSelectCatRoute(
     onBackClick: () -> Unit,
-    onNavToNaming: (Int) -> Unit,
+    onNavToNaming: (Int, String?) -> Unit,
     modifier: Modifier = Modifier,
     onboardingSelectCatViewModel: OnboardingSelectCatViewModel = hiltViewModel()
 ) {
@@ -61,7 +61,10 @@ fun OnboardingSelectCatRoute(
     onboardingSelectCatViewModel.effects.collectWithLifecycle { effect ->
         when (effect) {
             is SelectCatSideEffect.OnNavToNaming -> {
-                onNavToNaming(effect.no)
+                onNavToNaming(
+                    effect.no,
+                    effect.catName
+                )
             }
         }
     }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/select/OnboardingSelectCatViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/select/OnboardingSelectCatViewModel.kt
@@ -26,7 +26,7 @@ sealed interface SelectCatEvent : ViewEvent {
 }
 
 sealed interface SelectCatSideEffect : ViewSideEffect {
-    data class OnNavToNaming(val no: Int) : SelectCatSideEffect
+    data class OnNavToNaming(val no: Int, val catName: String?) : SelectCatSideEffect
 }
 
 @HiltViewModel
@@ -69,7 +69,8 @@ class OnboardingSelectCatViewModel @Inject constructor(
     private fun updateSelectCatType(catNo: Int) {
         viewModelScope.launch {
             catSettingRepository.updateCatType(catNo).onSuccess {
-                setEffect(SelectCatSideEffect.OnNavToNaming(catNo))
+                val catName = state.value.cats.find { it.no == catNo }
+                setEffect(SelectCatSideEffect.OnNavToNaming(catNo, catName?.name))
             }.onFailure {
                 Timber.e(it)
             }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingScreen.kt
@@ -53,7 +53,7 @@ import com.pomonyang.mohanyang.presentation.designsystem.icon.MnMediumIcon
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnColor
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnRadius
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
-import com.pomonyang.mohanyang.presentation.designsystem.tooltip.tooltip
+import com.pomonyang.mohanyang.presentation.designsystem.tooltip.guideTooltip
 import com.pomonyang.mohanyang.presentation.designsystem.topappbar.MnTopAppBar
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.TimeSetting
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
@@ -221,7 +221,7 @@ private fun CatRive(
             modifier = Modifier
                 .size(240.dp)
                 .background(MnTheme.backgroundColorScheme.secondary)
-                .tooltip(
+                .guideTooltip(
                     modifier = Modifier.padding(top = 20.dp),
                     enabled = showTooltip,
                     content = stringResource(R.string.tooltip_rest_content),
@@ -260,7 +260,7 @@ private fun PomodoroDetailSetting(
                 .padding(bottom = MnSpacing.medium)
                 .clip(RoundedCornerShape(MnRadius.xSmall))
                 .clickable { onAction(PomodoroSettingEvent.ClickCategory) }
-                .tooltip(
+                .guideTooltip(
                     enabled = categoryTooltip,
                     content = stringResource(R.string.tooltip_category_content),
                     anchorPadding = PaddingValues(bottom = MnSpacing.medium),
@@ -278,7 +278,7 @@ private fun PomodoroDetailSetting(
         Row(
             modifier = Modifier
                 .padding(horizontal = MnSpacing.twoXLarge)
-                .tooltip(
+                .guideTooltip(
                     enabled = timeTooltip,
                     content = stringResource(R.string.tooltip_time_content),
                     anchorPadding = PaddingValues(bottom = MnSpacing.medium),


### PR DESCRIPTION
## 작업 내용

기존 툴팁은 무조건 `fillMaxSize` 를 하고 있기 때문에 이벤트가 Popup이 먹어버리는 문제가 존재 해서 진짜 Tooltip 위치 만큼만 Popup이 뜰 수 있게 `popupPositionProvider` 활용한 tooltip 추가

## 체크리스트
- [ ] 빌드 확인

## 동작 화면

[Screen_recording_20240813_213432.webm](https://github.com/user-attachments/assets/1169bd0b-47fe-4b42-b4e5-dadcd9835960)


## 살려주세요

