### PR TITLE
[CAT-203] FCM 세팅 및 MnFirebaseMessagingService 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation(libs.material)
     implementation(libs.bundles.androidx.compose.navigation)
     implementation(libs.androidx.core.splashscreen)
+    implementation(libs.firebase.messaging)
 
     // module impl
     implementation(projects.data)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,18 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.Mohanyang"
         tools:targetApi="31">
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_icon"
+            android:resource="@drawable/ic_null" />
+       
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_color"
+            android:resource="@color/black" />
+
+        <meta-data
+            android:name="com.google.firebase.messaging.default_notification_channel_id"
+            android:value="@string/channel_id" />
+
         <activity
             android:name="com.pomonyang.mohanyang.MainActivity"
             android:exported="true"
@@ -31,6 +43,15 @@
         </activity>
         <receiver android:name=".notification.LocalNotificationReceiver" />
         <service android:name=".notification.FocusNotificationService" />
+
+        <service
+            android:name=".notification.MnFirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
@@ -39,7 +39,6 @@ import com.pomonyang.mohanyang.ui.rememberMohaNyangAppState
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import timber.log.Timber
 
 @AndroidEntryPoint
@@ -66,12 +65,10 @@ class MainActivity : ComponentActivity() {
 
         createNotificationChannel()
         handleSplashScreen()
+        initializeFCM()
 
         enableEdgeToEdge()
 
-        // createNotificationChannel()
-        initializeFCM()
-        runBlocking { userRepository.getDeviceId() }.also { Timber.d("$it") }
         setContent {
             val coroutineScope = rememberCoroutineScope()
             val activity = (LocalContext.current as? Activity)

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/MnFirebaseMessagingService.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/MnFirebaseMessagingService.kt
@@ -1,0 +1,55 @@
+package com.pomonyang.mohanyang.notification
+
+import android.Manifest
+import android.content.pm.PackageManager
+import androidx.core.app.ActivityCompat
+import com.google.firebase.messaging.FirebaseMessagingService
+import com.google.firebase.messaging.RemoteMessage
+import com.pomonyang.mohanyang.data.repository.push.PushAlarmRepository
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import timber.log.Timber
+
+@AndroidEntryPoint
+internal class MnFirebaseMessagingService : FirebaseMessagingService() {
+    private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+
+    @Inject
+    lateinit var pushAlarmRepository: PushAlarmRepository
+
+    private val isPushEnabled = true // TODO 사용자 정보 가져오기
+
+    override fun onNewToken(token: String) {
+        if (isPushEnabled) {
+            scope.launch {
+                pushAlarmRepository.apply {
+                    saveFcmToken(token)
+                    registerPushToken(token)
+                }
+            }
+        }
+    }
+
+    override fun onMessageReceived(remoteMessage: RemoteMessage) {
+        if (ActivityCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+            return
+        }
+
+        if (!isPushEnabled) return
+
+        val notification = remoteMessage.notification ?: return
+
+        // TODO notify 로직 추가
+        Timber.d("FCM notification : ${notification.title}\n${notification.body}")
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        scope.cancel()
+    }
+}

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/MnFirebaseMessagingService.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/MnFirebaseMessagingService.kt
@@ -3,17 +3,19 @@ package com.pomonyang.mohanyang.notification
 import android.Manifest
 import android.content.pm.PackageManager
 import androidx.core.app.ActivityCompat
+import androidx.core.app.NotificationManagerCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.pomonyang.mohanyang.data.repository.push.PushAlarmRepository
+import com.pomonyang.mohanyang.notification.util.defaultNotification
 import dagger.hilt.android.AndroidEntryPoint
+import java.util.*
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @AndroidEntryPoint
 internal class MnFirebaseMessagingService : FirebaseMessagingService() {
@@ -44,8 +46,15 @@ internal class MnFirebaseMessagingService : FirebaseMessagingService() {
 
         val notification = remoteMessage.notification ?: return
 
-        // TODO notify 로직 추가
-        Timber.d("FCM notification : ${notification.title}\n${notification.body}")
+        val builder = applicationContext.defaultNotification()
+        builder.apply {
+            setContentTitle(notification.title)
+            setContentText(notification.body)
+        }
+
+        val id = UUID.randomUUID().hashCode()
+
+        NotificationManagerCompat.from(this).notify(id, builder.build())
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/util/NotificationUtils.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/util/NotificationUtils.kt
@@ -58,5 +58,5 @@ fun getTriggerTimeInMillis(time: LocalTime): Long {
 }
 
 fun Context.isNotificationGranted(): Boolean = (
-    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && PackageManager.PERMISSION_DENIED == ContextCompat.checkSelfPermission(this, android.Manifest.permission.POST_NOTIFICATIONS)
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && PackageManager.PERMISSION_GRANTED == ContextCompat.checkSelfPermission(this, android.Manifest.permission.POST_NOTIFICATIONS)
     )

--- a/data/src/main/java/com/pomonyang/mohanyang/data/local/datastore/datasource/token/TokenLocalDataSource.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/local/datastore/datasource/token/TokenLocalDataSource.kt
@@ -3,7 +3,9 @@ package com.pomonyang.mohanyang.data.local.datastore.datasource.token
 interface TokenLocalDataSource {
     suspend fun saveAccessToken(accessToken: String)
     suspend fun saveRefreshToken(refreshToken: String)
+    suspend fun saveFcmToken(fcmToken: String)
     suspend fun getAccessToken(): String
     suspend fun getRefreshToken(): String
+    suspend fun getFcmToken(): String
     suspend fun clear()
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/local/datastore/datasource/token/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/local/datastore/datasource/token/TokenLocalDataSourceImpl.kt
@@ -27,6 +27,12 @@ internal class TokenLocalDataSourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun saveFcmToken(fcmToken: String) {
+        dataStore.edit { preferences ->
+            preferences[FCM_TOKEN_KEY] = fcmToken
+        }
+    }
+
     override suspend fun clear() {
         dataStore.edit { preferences ->
             preferences[ACCESS_TOKEN_KEY] = ""
@@ -50,9 +56,18 @@ internal class TokenLocalDataSourceImpl @Inject constructor(
         }
     }.first()[REFRESH_TOKEN_KEY] ?: ""
 
+    override suspend fun getFcmToken(): String = dataStore.data.catch { exception ->
+        if (exception is IOException) {
+            emit(emptyPreferences())
+        } else {
+            throw exception
+        }
+    }.first()[FCM_TOKEN_KEY] ?: ""
+
     companion object {
         const val TOKEN_PREFERENCES_NAME = "token_preferences"
         private val ACCESS_TOKEN_KEY = stringPreferencesKey("access_token")
         private val REFRESH_TOKEN_KEY = stringPreferencesKey("refresh_token")
+        private val FCM_TOKEN_KEY = stringPreferencesKey("fcm_token")
     }
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/remote/model/request/RegisterPushTokenRequest.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/remote/model/request/RegisterPushTokenRequest.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class RegisterPushTokenRequest(
     val deviceToken: String,
-    val deviceType: String = "ANDROID"
+    val deviceType: String
 )

--- a/data/src/main/java/com/pomonyang/mohanyang/data/remote/model/request/RegisterPushTokenRequest.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/remote/model/request/RegisterPushTokenRequest.kt
@@ -1,0 +1,9 @@
+package com.pomonyang.mohanyang.data.remote.model.request
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class RegisterPushTokenRequest(
+    val deviceToken: String,
+    val deviceType: String = "ANDROID"
+)

--- a/data/src/main/java/com/pomonyang/mohanyang/data/remote/service/MohaNyangService.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/remote/service/MohaNyangService.kt
@@ -1,5 +1,6 @@
 package com.pomonyang.mohanyang.data.remote.service
 
+import com.pomonyang.mohanyang.data.remote.model.request.RegisterPushTokenRequest
 import com.pomonyang.mohanyang.data.remote.model.request.UpdateCatInfoRequest
 import com.pomonyang.mohanyang.data.remote.model.request.UpdateCatTypeRequest
 import com.pomonyang.mohanyang.data.remote.model.request.UpdateCategoryInfoRequest
@@ -7,7 +8,9 @@ import com.pomonyang.mohanyang.data.remote.model.response.CatTypeResponse
 import com.pomonyang.mohanyang.data.remote.model.response.PomodoroSettingResponse
 import com.pomonyang.mohanyang.data.remote.model.response.UserInfoResponse
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.PUT
 import retrofit2.http.Path
 
@@ -41,4 +44,18 @@ interface MohaNyangService {
 
     @GET("/api/v1/users/me")
     suspend fun getMyInfo(): Result<UserInfoResponse>
+
+    @POST("/api/v1/device-tokens")
+    suspend fun registerPushToken(
+        @Body registerPushTokenRequest: RegisterPushTokenRequest
+    ): Result<Unit>
+
+    @DELETE("/api/v1/device-tokens")
+    suspend fun unRegisterPushToken(): Result<Unit>
+
+    @POST("/api/v1/notifications")
+    suspend fun subscribeNotification(): Result<Unit>
+
+    @DELETE("/api/v1/notifications")
+    suspend fun unSubscribeNotification(): Result<Unit>
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/di/RepositoryModule.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/di/RepositoryModule.kt
@@ -4,6 +4,8 @@ import com.pomonyang.mohanyang.data.repository.cat.CatSettingRepository
 import com.pomonyang.mohanyang.data.repository.cat.CatSettingRepositoryImpl
 import com.pomonyang.mohanyang.data.repository.pomodoro.PomodoroSettingRepository
 import com.pomonyang.mohanyang.data.repository.pomodoro.PomodoroSettingRepositoryImpl
+import com.pomonyang.mohanyang.data.repository.push.PushAlarmRepository
+import com.pomonyang.mohanyang.data.repository.push.PushAlarmRepositoryImpl
 import com.pomonyang.mohanyang.data.repository.user.UserRepository
 import com.pomonyang.mohanyang.data.repository.user.UserRepositoryImpl
 import dagger.Binds
@@ -33,4 +35,10 @@ internal abstract class RepositoryModule {
     internal abstract fun provideCatSettingRepository(
         catSettingRepositoryImpl: CatSettingRepositoryImpl
     ): CatSettingRepository
+
+    @Binds
+    @Singleton
+    internal abstract fun providePushAlarmRepository(
+        pushAlarmRepositoryImpl: PushAlarmRepositoryImpl
+    ): PushAlarmRepository
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/push/PushAlarmRepository.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/push/PushAlarmRepository.kt
@@ -1,0 +1,10 @@
+package com.pomonyang.mohanyang.data.repository.push
+
+interface PushAlarmRepository {
+    suspend fun saveFcmToken(fcmToken: String)
+    suspend fun getFcmToken(): String
+    suspend fun registerPushToken(fcmToken: String): Result<Unit>
+    suspend fun unRegisterPushToken(): Result<Unit>
+    suspend fun subscribeNotification(): Result<Unit>
+    suspend fun unSubscribeNotification(): Result<Unit>
+}

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/push/PushAlarmRepositoryImpl.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/push/PushAlarmRepositoryImpl.kt
@@ -13,11 +13,15 @@ class PushAlarmRepositoryImpl @Inject constructor(
 
     override suspend fun getFcmToken(): String = tokenLocalDataSource.getFcmToken()
 
-    override suspend fun registerPushToken(fcmToken: String): Result<Unit> = mohaNyangService.registerPushToken(RegisterPushTokenRequest(fcmToken))
+    override suspend fun registerPushToken(fcmToken: String): Result<Unit> = mohaNyangService.registerPushToken(RegisterPushTokenRequest(deviceToken = fcmToken, deviceType = DEVICE_TYPE))
 
     override suspend fun unRegisterPushToken(): Result<Unit> = mohaNyangService.unRegisterPushToken()
 
     override suspend fun subscribeNotification(): Result<Unit> = mohaNyangService.subscribeNotification()
 
     override suspend fun unSubscribeNotification(): Result<Unit> = mohaNyangService.unSubscribeNotification()
+
+    companion object {
+        private const val DEVICE_TYPE = "ANDROID"
+    }
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/push/PushAlarmRepositoryImpl.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/push/PushAlarmRepositoryImpl.kt
@@ -1,0 +1,23 @@
+package com.pomonyang.mohanyang.data.repository.push
+
+import com.pomonyang.mohanyang.data.local.datastore.datasource.token.TokenLocalDataSource
+import com.pomonyang.mohanyang.data.remote.model.request.RegisterPushTokenRequest
+import com.pomonyang.mohanyang.data.remote.service.MohaNyangService
+import javax.inject.Inject
+
+class PushAlarmRepositoryImpl @Inject constructor(
+    private val mohaNyangService: MohaNyangService,
+    private val tokenLocalDataSource: TokenLocalDataSource
+) : PushAlarmRepository {
+    override suspend fun saveFcmToken(fcmToken: String) = tokenLocalDataSource.saveFcmToken(fcmToken)
+
+    override suspend fun getFcmToken(): String = tokenLocalDataSource.getFcmToken()
+
+    override suspend fun registerPushToken(fcmToken: String): Result<Unit> = mohaNyangService.registerPushToken(RegisterPushTokenRequest(fcmToken))
+
+    override suspend fun unRegisterPushToken(): Result<Unit> = mohaNyangService.unRegisterPushToken()
+
+    override suspend fun subscribeNotification(): Result<Unit> = mohaNyangService.subscribeNotification()
+
+    override suspend fun unSubscribeNotification(): Result<Unit> = mohaNyangService.unSubscribeNotification()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,6 +33,7 @@ firebase-crashlytics-gradle = "3.0.2"
 firebase-pref-gradle = "1.4.2"
 firebase-appdistribution-gradle = "5.0.0"
 firebase-bom = "33.1.2"
+firebaes-messaging = "23.2.1"
 
 # etc
 timber = "5.0.1"
@@ -99,6 +100,7 @@ firebase-appdistribution-gradle = { group = "com.google.firebase", name = "fireb
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebase-bom" }
 firebase-perf = { module = "com.google.firebase:firebase-perf" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics-ktx" }
+firebase-messaging = { module = "com.google.firebase:firebase-messaging-ktx", version.ref = "firebaes-messaging" }
 
 # etc
 timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }


### PR DESCRIPTION
> 푸쉬 알림오는 로직은 지금 열려있는 알림 PR 닫히면 같이 연결할게~

## 작업 내용
- 프로젝트 FCM 세팅 및 토큰 발급 로직 구현
- FCM Token datastore 저장 로직 구현
- Token 갱신 API 연결

## 체크리스트
- [x] 빌드 확인
- [x] 알림 허용되어 있는 지 확인 후 테스트
- [x] FCM Token 발급되는거 확인
- [x] FCM Test API 사용해서 알림 오는거 확인
> 로그에 찍히는 token으로 api 테스트하면됩니다 (/papi/v1/notification)

## 동작 화면
![스크린샷 2024-08-14 오후 3 18 02](https://github.com/user-attachments/assets/94cacb5d-da68-4d0e-8121-ef6059810785)
![image](https://github.com/user-attachments/assets/2c3c8c89-0013-43f4-ab13-fdedfce81ba5)

## 살려주세요

