### PR TITLE
[CAT-219] 뽀모도르 비즈니스 로직 분리 및 공통 컴포넌트 분리

### DIFF
--- a/app/src/main/java/com/pomonyang/mohanyang/navigation/MohaNyangNavHost.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/navigation/MohaNyangNavHost.kt
@@ -1,6 +1,7 @@
 package com.pomonyang.mohanyang.navigation
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import com.pomonyang.mohanyang.presentation.screen.onboarding.Onboarding
@@ -17,6 +18,7 @@ internal fun MohaNyangNavHost(
 ) {
     val navHostController = mohaNyangAppState.navHostController
     val navigateUp: () -> Unit = { navHostController.navigateUp() }
+    val onBackPressed: () -> Unit = remember { { navHostController.popBackStack() } }
 
     val startDestination: Any = if (mohaNyangAppState.isNewUser) {
         Onboarding
@@ -30,12 +32,14 @@ internal fun MohaNyangNavHost(
         modifier = modifier
     ) {
         onboardingScreen(
-            navHostController = mohaNyangAppState.navHostController
+            navHostController = mohaNyangAppState.navHostController,
+            onBackPressed = onBackPressed
         )
 
         pomodoroScreen(
             isNewUser = mohaNyangAppState.isNewUser,
             navHostController = mohaNyangAppState.navHostController,
+            onBackPressed = onBackPressed,
             onShowSnackbar = onShowSnackbar
         )
     }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/component/CatRive.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/component/CatRive.kt
@@ -1,0 +1,88 @@
+package com.pomonyang.mohanyang.presentation.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.pomonyang.mohanyang.presentation.designsystem.tooltip.tooltip
+import com.pomonyang.mohanyang.presentation.theme.MnTheme
+import kotlinx.coroutines.delay
+
+@Composable
+fun CatRive(
+    modifier: Modifier = Modifier,
+    tooltipMessage: String? = null,
+    catName: String? = null,
+    showTooltip: Boolean = false
+) {
+    var tooltipEnabled by remember { mutableStateOf(showTooltip) }
+    val tooltipModifier = if (tooltipEnabled && tooltipMessage != null) {
+        Modifier.tooltip(
+            enabled = showTooltip,
+            tooltipPadding = PaddingValues(top = 20.dp),
+            content = tooltipMessage
+        )
+    } else {
+        Modifier
+    }
+
+    LaunchedEffect(tooltipMessage) {
+        if (tooltipMessage != null) {
+            tooltipEnabled = false
+            delay(50)
+            tooltipEnabled = true
+        }
+    }
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Box(
+            modifier = modifier
+                .size(240.dp)
+                .background(MnTheme.backgroundColorScheme.secondary)
+                .then(tooltipModifier),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(text = "image")
+        }
+
+        catName?.let {
+            Text(
+                modifier = Modifier.padding(top = 20.dp),
+                text = it,
+                style = MnTheme.typography.header4,
+                color = MnTheme.textColorScheme.tertiary
+            )
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun CatRivePreview() {
+    MnTheme {
+        CatRive(tooltipMessage = "잘 집중하고 있는 거냥?")
+    }
+}
+
+@Preview
+@Composable
+private fun CatRiveNamePreview() {
+    MnTheme {
+        CatRive(tooltipMessage = "잘 집중하고 있는 거냥?", catName = "치즈냥")
+    }
+}

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/component/CategoryBox.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/component/CategoryBox.kt
@@ -1,4 +1,4 @@
-package com.pomonyang.mohanyang.presentation.screen.pomodoro.component
+package com.pomonyang.mohanyang.presentation.component
 
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/component/Timer.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/component/Timer.kt
@@ -1,0 +1,67 @@
+package com.pomonyang.mohanyang.presentation.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import com.pomonyang.mohanyang.presentation.screen.pomodoro.PomodoroTimerViewModel.Companion.DEFAULT_TIME
+import com.pomonyang.mohanyang.presentation.theme.MnTheme
+
+@Composable
+fun Timer(
+    time: String,
+    exceededTime: String,
+    modifier: Modifier = Modifier
+) {
+    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
+        Text(
+            text = time,
+            style = MnTheme.typography.header1,
+            color = MnTheme.textColorScheme.primary
+        )
+        if (exceededTime != DEFAULT_TIME) {
+            Text(
+                text = "$exceededTime 초과",
+                style = MnTheme.typography.header4,
+                color = MnTheme.backgroundColorScheme.accent1
+            )
+        }
+    }
+}
+
+private class TimerPreviewParameterProvider : PreviewParameterProvider<TimerPreviewParams> {
+    override val values = sequenceOf(
+        TimerPreviewParams(
+            time = "25:00",
+            exceededTime = DEFAULT_TIME
+        ),
+        TimerPreviewParams(
+            time = "00:00",
+            exceededTime = "5:00"
+        ),
+        TimerPreviewParams(
+            time = "10:00",
+            exceededTime = DEFAULT_TIME
+        )
+    )
+}
+
+private data class TimerPreviewParams(
+    val time: String,
+    val exceededTime: String
+)
+
+@Preview(showBackground = true)
+@Composable
+private fun TimerPreview(
+    @PreviewParameter(TimerPreviewParameterProvider::class) params: TimerPreviewParams
+) {
+    Timer(
+        time = params.time,
+        exceededTime = params.exceededTime
+    )
+}

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/tooltip/MnTooltip.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/tooltip/MnTooltip.kt
@@ -93,10 +93,12 @@ fun Modifier.tooltip(
     horizontalAlignment: Alignment.Horizontal = Alignment.CenterHorizontally,
     verticalAlignment: Alignment.Vertical = Alignment.Top,
     anchorAlignment: Alignment = Alignment.BottomCenter,
+    tooltipPadding: PaddingValues = PaddingValues(),
     anchorPadding: PaddingValues = PaddingValues(),
     contentAlign: TextAlign = TextAlign.Center,
     enabled: Boolean = true
 ): Modifier {
+    val density = LocalDensity.current
     var positionInRoot by remember { mutableStateOf(IntOffset.Zero) }
     var tooltipContentSize by remember { mutableStateOf(IntSize(0, 0)) }
     var componentSize by remember { mutableStateOf(IntSize(0, 0)) }
@@ -112,15 +114,30 @@ fun Modifier.tooltip(
                     windowSize: IntSize,
                     layoutDirection: LayoutDirection,
                     popupContentSize: IntSize
-                ): IntOffset = calculateOffset(
-                    positionInRoot = positionInRoot,
-                    componentSize = componentSize,
-                    tooltipSize = popupContentSize,
-                    screenWidthPx = windowSize.width,
-                    screenHeightPx = windowSize.height,
-                    horizontalAlignment = horizontalAlignment,
-                    verticalAlignment = verticalAlignment
-                )
+                ): IntOffset {
+                    val offset = calculateOffset(
+                        positionInRoot = positionInRoot,
+                        componentSize = componentSize,
+                        tooltipSize = popupContentSize,
+                        screenWidthPx = windowSize.width,
+                        screenHeightPx = windowSize.height,
+                        horizontalAlignment = horizontalAlignment,
+                        verticalAlignment = verticalAlignment
+                    )
+                    val horizontalPadding = with(density) {
+                        tooltipPadding.calculateLeftPadding(layoutDirection).roundToPx() -
+                            tooltipPadding.calculateRightPadding(layoutDirection).roundToPx()
+                    }
+                    val verticalPadding = with(density) {
+                        tooltipPadding.calculateTopPadding().roundToPx() -
+                            tooltipPadding.calculateBottomPadding().roundToPx()
+                    }
+
+                    return IntOffset(
+                        x = offset.x + horizontalPadding,
+                        y = offset.y + verticalPadding
+                    )
+                }
             }
         ) {
             MnTooltipImpl(
@@ -290,7 +307,11 @@ private fun MnTooltipImpl(
                 TooltipAnchor(
                     modifier = Modifier
                         .padding(arrowPadding)
-                        .width(tooltipContentSize.width.toFloat().pxToDp()),
+                        .width(
+                            tooltipContentSize.width
+                                .toFloat()
+                                .pxToDp()
+                        ),
                     anchorColor = tooltipColors.containerColor,
                     direction = arrowAlignment
                 )
@@ -300,7 +321,11 @@ private fun MnTooltipImpl(
                 TooltipAnchor(
                     modifier = Modifier
                         .padding(arrowPadding)
-                        .width(tooltipContentSize.width.toFloat().pxToDp()),
+                        .width(
+                            tooltipContentSize.width
+                                .toFloat()
+                                .pxToDp()
+                        ),
                     anchorColor = tooltipColors.containerColor,
                     direction = arrowAlignment
                 )

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/OnboardingNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/OnboardingNavigator.kt
@@ -28,7 +28,8 @@ internal data class OnboardingNamingCat(
 )
 
 fun NavGraphBuilder.onboardingScreen(
-    navHostController: NavHostController
+    navHostController: NavHostController,
+    onBackPressed: () -> Unit
 ) {
     navigation<Onboarding>(
         startDestination = OnboardingGuide
@@ -58,6 +59,7 @@ fun NavGraphBuilder.onboardingScreen(
             OnboardingNamingCatRoute(
                 catNo = catNo,
                 catName = catName,
+                onBackPressed = onBackPressed,
                 onBackClick = { navHostController.popBackStack() },
                 onNavToHome = {
                     navHostController.navigate(

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/guide/OnboardingGuideScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/guide/OnboardingGuideScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.mohanyang.presentation.R
+import com.pomonyang.mohanyang.presentation.component.CatRive
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButton
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonColorType
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonStyles
@@ -155,7 +156,7 @@ private fun OnboardingGuideContent(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(MnSpacing.threeXLarge)
     ) {
-        CatRiveBox()
+        CatRive()
         TextGuide(content)
     }
 }
@@ -183,17 +184,6 @@ private fun TextGuide(
             color = MnTheme.textColorScheme.secondary
         )
     }
-}
-
-@Composable
-private fun CatRiveBox(
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier = modifier
-            .size(240.dp)
-            .background(MnTheme.backgroundColorScheme.secondary)
-    )
 }
 
 @Composable
@@ -231,12 +221,6 @@ private fun PageIndicator(
             )
         }
     }
-}
-
-@Preview
-@Composable
-private fun CatRivePreview() {
-    CatRiveBox()
 }
 
 @Preview

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/naming/OnboardingNamingCatScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/naming/OnboardingNamingCatScreen.kt
@@ -1,13 +1,11 @@
 package com.pomonyang.mohanyang.presentation.screen.onboarding.naming
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -20,7 +18,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -29,6 +26,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.mohanyang.presentation.R
+import com.pomonyang.mohanyang.presentation.component.CatRive
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButton
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonColorType
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonStyles
@@ -36,7 +34,6 @@ import com.pomonyang.mohanyang.presentation.designsystem.button.icon.MnIconButto
 import com.pomonyang.mohanyang.presentation.designsystem.textfield.MnTextField
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnColor
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
-import com.pomonyang.mohanyang.presentation.designsystem.tooltip.tooltip
 import com.pomonyang.mohanyang.presentation.designsystem.topappbar.MnTopAppBar
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
@@ -48,20 +45,30 @@ fun OnboardingNamingCatRoute(
     catName: String?,
     onBackClick: () -> Unit,
     onNavToHome: () -> Unit,
+    onBackPressed: () -> Unit,
     modifier: Modifier = Modifier,
     onboardingNamingCatViewModel: OnboardingNamingCatViewModel = hiltViewModel()
 ) {
+    var showNamingCatTooltip by remember { mutableStateOf(true) }
+
     onboardingNamingCatViewModel.effects.collectWithLifecycle { effect ->
         when (effect) {
             is NamingSideEffect.NavToHome -> {
+                showNamingCatTooltip = false
                 onNavToHome()
             }
         }
     }
 
+    BackHandler {
+        showNamingCatTooltip = false
+        onBackPressed()
+    }
+
     OnboardingNamingCatScreen(
         catNo = catNo,
         catName = catName,
+        showNamingCatTooltip = showNamingCatTooltip,
         onAction = onboardingNamingCatViewModel::handleEvent,
         onBackClick = onBackClick,
         modifier = modifier
@@ -72,6 +79,7 @@ fun OnboardingNamingCatRoute(
 fun OnboardingNamingCatScreen(
     catNo: Int,
     catName: String?,
+    showNamingCatTooltip: Boolean,
     onAction: (NamingEvent) -> Unit,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier
@@ -116,7 +124,13 @@ fun OnboardingNamingCatScreen(
 
         ) {
             item {
-                CatRive(modifier = Modifier.padding(top = 130.dp))
+                CatRive(
+                    modifier = Modifier
+                        .padding(top = 130.dp)
+                        .fillMaxWidth(),
+                    tooltipMessage = stringResource(id = R.string.naming_cat_tooltip),
+                    showTooltip = showNamingCatTooltip
+                )
                 Text(
                     modifier = Modifier.padding(
                         top = MnSpacing.twoXLarge,
@@ -155,25 +169,12 @@ fun OnboardingNamingCatScreen(
 }
 
 @Composable
-private fun CatRive(modifier: Modifier = Modifier) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(240.dp)
-            .background(MnTheme.backgroundColorScheme.secondary)
-            .tooltip(content = stringResource(id = R.string.naming_cat_tooltip)),
-        contentAlignment = Alignment.Center
-    ) {
-        Text(text = "image")
-    }
-}
-
-@Composable
-@Preview
+@Preview(showBackground = true)
 fun PreviewOnboardingNamingCatScreen() {
     OnboardingNamingCatScreen(
         catNo = 1,
         catName = "삼색이",
+        showNamingCatTooltip = true,
         onAction = { _ -> },
         onBackClick = {}
     )

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/select/OnboardingSelectCatScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/select/OnboardingSelectCatScreen.kt
@@ -33,6 +33,7 @@ import com.google.accompanist.permissions.rememberPermissionState
 import com.mohanyang.presentation.R
 import com.pomonyang.mohanyang.domain.model.cat.CatSelectionContent
 import com.pomonyang.mohanyang.domain.model.cat.CatType
+import com.pomonyang.mohanyang.presentation.component.CatRive
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButton
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonColorType
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonStyles
@@ -136,10 +137,12 @@ fun OnboardingSelectCatScreen(
             )
 
             CatRive(
-                modifier = Modifier.padding(
-                    top = MnSpacing.medium,
-                    bottom = 42.dp
-                )
+                modifier = Modifier
+                    .padding(
+                        top = MnSpacing.medium,
+                        bottom = 42.dp
+                    )
+                    .fillMaxWidth()
             )
 
             CatCategory(
@@ -253,21 +256,6 @@ fun EmptyAlarmExample(
             color = MnColor.Gray400,
             textAlign = TextAlign.Center
         )
-    }
-}
-
-@Composable
-private fun CatRive(
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier = modifier
-            .height(240.dp)
-            .fillMaxWidth()
-            .background(MnTheme.backgroundColorScheme.secondary),
-        contentAlignment = Alignment.Center
-    ) {
-        Text("image")
     }
 }
 

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroNavigator.kt
@@ -29,6 +29,7 @@ internal data object PomodoroRest
 fun NavGraphBuilder.pomodoroScreen(
     isNewUser: Boolean,
     onShowSnackbar: (String, String?) -> Unit,
+    onBackPressed: () -> Unit,
     navHostController: NavHostController
 ) {
     navigation<Pomodoro>(
@@ -38,6 +39,7 @@ fun NavGraphBuilder.pomodoroScreen(
             PomodoroSettingRoute(
                 isNewUser = isNewUser,
                 onShowSnackbar = onShowSnackbar,
+                onBackPressed = onBackPressed,
                 goTimeSetting = { isFocusTime ->
                     navHostController.navigate(
                         TimeSetting(isFocusTime)
@@ -61,6 +63,7 @@ fun NavGraphBuilder.pomodoroScreen(
 
         composable<PomodoroTimer> {
             PomodoroTimerRoute(
+                onBackPressed = onBackPressed,
                 goToRest = {
                     navHostController.navigate(PomodoroRest) {
                         popUpTo(navHostController.graph.findStartDestination().id) {

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroNavigator.kt
@@ -1,10 +1,12 @@
 package com.pomonyang.mohanyang.presentation.screen.pomodoro
 
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import androidx.navigation.toRoute
+import com.pomonyang.mohanyang.presentation.screen.pomodoro.rest.PomodoroRestRoute
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.setting.PomodoroSettingRoute
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.time.PomodoroTimeSettingRoute
 import kotlinx.serialization.Serializable
@@ -20,6 +22,9 @@ internal data class TimeSetting(val isFocusTime: Boolean)
 
 @Serializable
 internal data object PomodoroTimer
+
+@Serializable
+internal data object PomodoroRest
 
 fun NavGraphBuilder.pomodoroScreen(
     isNewUser: Boolean,
@@ -54,8 +59,30 @@ fun NavGraphBuilder.pomodoroScreen(
             }
         }
 
-        composable<PomodoroTimer> { backStackEntry ->
-            PomodoroTimerRoute()
+        composable<PomodoroTimer> {
+            PomodoroTimerRoute(
+                goToRest = {
+                    navHostController.navigate(PomodoroRest) {
+                        popUpTo(navHostController.graph.findStartDestination().id) {
+                            saveState = true
+                        }
+                        popUpTo(PomodoroTimer) {
+                            inclusive = true
+                        }
+                        restoreState = true
+                    }
+                },
+                goToPomodoroSetting = {
+                    navHostController.navigate(PomodoroSetting) {
+                        popUpTo(0) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                }
+            )
+        }
+
+        composable<PomodoroRest> {
+            PomodoroRestRoute()
         }
     }
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerScreen.kt
@@ -23,6 +23,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mohanyang.presentation.R
 import com.pomonyang.mohanyang.presentation.component.CategoryBox
+import com.pomonyang.mohanyang.presentation.component.Timer
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButton
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonColorType
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonStyles
@@ -31,7 +32,6 @@ import com.pomonyang.mohanyang.presentation.designsystem.button.text.MnTextButto
 import com.pomonyang.mohanyang.presentation.designsystem.icon.MnSmallIcon
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
 import com.pomonyang.mohanyang.presentation.designsystem.topappbar.MnTopAppBar
-import com.pomonyang.mohanyang.presentation.screen.pomodoro.PomodoroTimerViewModel.Companion.DEFAULT_TIME
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.DevicePreviews
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
@@ -91,11 +91,22 @@ private fun PomodoroTimerScreen(
 
         CatRive()
 
+        Row(
+            modifier = Modifier.padding(top = MnSpacing.xLarge),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            MnSmallIcon(resourceId = R.drawable.ic_null)
+            Text(
+                modifier = Modifier.padding(MnSpacing.xSmall),
+                text = stringResource(id = typeRes),
+                style = MnTheme.typography.header5,
+                color = MnTheme.textColorScheme.secondary
+            )
+        }
+
         Timer(
-            title = stringResource(id = typeRes),
             time = time,
-            exceededTime = exceededTime,
-            modifier = Modifier.padding(top = MnSpacing.xLarge)
+            exceededTime = exceededTime
         )
 
         Spacer(modifier = Modifier.weight(1f))
@@ -126,41 +137,6 @@ private fun CatRive(modifier: Modifier = Modifier) {
         contentAlignment = Alignment.Center
     ) {
         Text(text = "image")
-    }
-}
-
-@Composable
-fun Timer(
-    title: String,
-    time: String,
-    exceededTime: String,
-    modifier: Modifier = Modifier
-) {
-    Column(modifier = modifier, horizontalAlignment = Alignment.CenterHorizontally) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            MnSmallIcon(resourceId = R.drawable.ic_null)
-            Text(
-                modifier = Modifier.padding(MnSpacing.xSmall),
-                text = title,
-                style = MnTheme.typography.header5,
-                color = MnTheme.textColorScheme.secondary
-            )
-        }
-
-        Text(
-            text = time,
-            style = MnTheme.typography.header1,
-            color = MnTheme.textColorScheme.primary
-        )
-        if (exceededTime != DEFAULT_TIME) {
-            Text(
-                text = "$exceededTime 초과",
-                style = MnTheme.typography.header4,
-                color = MnTheme.backgroundColorScheme.accent1
-            )
-        }
     }
 }
 

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mohanyang.presentation.R
+import com.pomonyang.mohanyang.presentation.component.CategoryBox
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButton
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonColorType
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonStyles
@@ -31,7 +32,6 @@ import com.pomonyang.mohanyang.presentation.designsystem.icon.MnSmallIcon
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
 import com.pomonyang.mohanyang.presentation.designsystem.topappbar.MnTopAppBar
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.PomodoroTimerViewModel.Companion.DEFAULT_TIME
-import com.pomonyang.mohanyang.presentation.screen.pomodoro.component.CategoryBox
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.DevicePreviews
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
@@ -40,12 +40,16 @@ import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
 fun PomodoroTimerRoute(
     modifier: Modifier = Modifier,
     pomodoroTimerViewModel: PomodoroTimerViewModel = hiltViewModel(),
-    goToRest: () -> Unit
+    goToRest: () -> Unit,
+    goToPomodoroSetting: () -> Unit
 ) {
     val state by pomodoroTimerViewModel.state.collectAsStateWithLifecycle()
 
     pomodoroTimerViewModel.effects.collectWithLifecycle {
-        goToRest()
+        when (it) {
+            PomodoroTimerEffect.GoToPomodoroRest -> goToRest()
+            PomodoroTimerEffect.GoToPomodoroSetting -> goToPomodoroSetting()
+        }
     }
 
     LaunchedEffect(Unit) {

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
@@ -1,27 +1,45 @@
 package com.pomonyang.mohanyang.presentation.screen.pomodoro
 
 import androidx.lifecycle.viewModelScope
+import com.mohanyang.presentation.BuildConfig
 import com.pomonyang.mohanyang.domain.usecase.GetSelectedPomodoroSettingUseCase
 import com.pomonyang.mohanyang.presentation.base.BaseViewModel
 import com.pomonyang.mohanyang.presentation.base.ViewEvent
 import com.pomonyang.mohanyang.presentation.base.ViewSideEffect
 import com.pomonyang.mohanyang.presentation.base.ViewState
-import com.pomonyang.mohanyang.presentation.screen.pomodoro.PomodoroTimerViewModel.Companion.DEFAULT_TIME
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.*
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 data class PomodoroTimerState(
+    val focusTime: Int = 0,
+    val exceededTime: Int = 0,
     val type: String = "",
-    val focusTime: String = DEFAULT_TIME,
-    val exceededTime: String = DEFAULT_TIME,
     val categoryNo: Int = -1
-) : ViewState
+) : ViewState {
+    fun displayFocusTime(): String = focusTime.formatTime()
+
+    fun displayRestTime(): String = exceededTime.formatTime()
+
+    private fun Int.formatTime(): String {
+        val minutesPart = this / 60
+        val secondsPart = this % 60
+        return String.format(Locale.KOREAN, "%02d:%02d", minutesPart, secondsPart)
+    }
+}
 
 sealed interface PomodoroTimerEvent : ViewEvent {
     data object Init : PomodoroTimerEvent
+    data object ClickRest : PomodoroTimerEvent
+    data object ClickHome : PomodoroTimerEvent
 }
 
 sealed interface PomodoroTimerEffect : ViewSideEffect
@@ -30,30 +48,58 @@ sealed interface PomodoroTimerEffect : ViewSideEffect
 class PomodoroTimerViewModel @Inject constructor(
     private val getSelectedPomodoroSettingUseCase: GetSelectedPomodoroSettingUseCase
 ) : BaseViewModel<PomodoroTimerState, PomodoroTimerEvent, PomodoroTimerEffect>() {
+
+    private var timerJob: Job? = null
+
     override fun setInitialState(): PomodoroTimerState = PomodoroTimerState()
 
     override fun handleEvent(event: PomodoroTimerEvent) {
+        Timber.tag("koni").d("handleEvent > $event")
         when (event) {
             PomodoroTimerEvent.Init -> viewModelScope.launch {
-                val selectedPomodoroSetting = getSelectedPomodoroSettingUseCase().first()
+                getSelectedPomodoroSettingUseCase().first()?.let {
+                    updateState {
+                        copy(
+                            type = it.title,
+                            focusTime = (it.focusTime.times(60)).formatTime(),
+                            categoryNo = it.categoryNo
+                        )
+                    }
+                } ?: run { /* TODO 예외 처리 필요할지 고민 */ }
+            }
+
+            PomodoroTimerEvent.ClickRest -> {
+            }
+
+            PomodoroTimerEvent.ClickHome -> TODO()
+        }
+    }
+
+    private fun startTimer() {
+        timerJob?.cancel()
+        timerJob = CoroutineScope(Dispatchers.IO).launch {
+            while (isActive) {
+                delay(TIMER_DELAY)
                 updateState {
-                    copy(
-                        type = selectedPomodoroSetting.title,
-                        focusTime = (selectedPomodoroSetting.focusTime.times(60)).formatTime(),
-                        categoryNo = selectedPomodoroSetting.categoryNo
-                    )
+                    if (focusTime > MIN_FOCUS_TIME) {
+                        copy(focusTime = focusTime - ONE_SECOND)
+                    } else {
+                        val newExceedTime = exceededTime + ONE_SECOND
+                        if (newExceedTime >= MAX_EXCEEDED_TIME) {
+                            timerJob?.cancel()
+                        }
+                        copy(exceededTime = newExceedTime)
+                    }
                 }
             }
         }
     }
 
-    private fun Int.formatTime(): String {
-        val minutesPart = this / 60
-        val secondsPart = this % 60
-        return String.format(Locale.KOREAN, "%02d:%02d", minutesPart, secondsPart)
-    }
-
     companion object {
+        private val TIMER_DELAY = if (BuildConfig.DEBUG) 1_000L else 1_000L
+        private const val MAX_EXCEEDED_TIME = 3600
+        private const val MIN_FOCUS_TIME = 0
+        private const val ONE_SECOND = 1
         const val DEFAULT_TIME = "00:00"
     }
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
@@ -53,15 +53,15 @@ class PomodoroTimerViewModel @Inject constructor(
         Timber.tag("koni").d("handleEvent > $event")
         when (event) {
             PomodoroTimerEvent.Init -> viewModelScope.launch {
-                getSelectedPomodoroSettingUseCase().first()?.let {
-                    updateState {
-                        copy(
-                            type = it.title,
-                            focusTime = (it.focusTime.times(60)).formatTime(),
-                            categoryNo = it.categoryNo
-                        )
-                    }
-                } ?: run { /* TODO 예외 처리 필요할지 고민 */ }
+                val selectedPomodoroSetting = getSelectedPomodoroSettingUseCase().first()
+                updateState {
+                    copy(
+                        type = selectedPomodoroSetting.title,
+                        focusTime = (selectedPomodoroSetting.focusTime.times(60)),
+                        categoryNo = selectedPomodoroSetting.categoryNo
+                    )
+                }
+                startTimer()
             }
 
             PomodoroTimerEvent.ClickRest -> setEffect(PomodoroTimerEffect.GoToPomodoroRest)

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestRoute.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestRoute.kt
@@ -1,0 +1,33 @@
+package com.pomonyang.mohanyang.presentation.screen.pomodoro.rest
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+
+@Composable
+fun PomodoroRestRoute(
+    modifier: Modifier = Modifier
+) {
+    PomodoroRestScreen()
+}
+
+@Composable
+fun PomodoroRestScreen() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(text = "Pomodoro Rest")
+    }
+}
+
+@Preview
+@Composable
+private fun PomodoroRestScreenPreview() {
+}

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingScreen.kt
@@ -42,6 +42,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mohanyang.presentation.R
 import com.pomonyang.mohanyang.domain.model.setting.PomodoroCategoryModel
+import com.pomonyang.mohanyang.presentation.component.CategoryBox
 import com.pomonyang.mohanyang.presentation.designsystem.bottomsheet.MnBottomSheet
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButton
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonColorType
@@ -54,7 +55,6 @@ import com.pomonyang.mohanyang.presentation.designsystem.token.MnRadius
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
 import com.pomonyang.mohanyang.presentation.designsystem.tooltip.guideTooltip
 import com.pomonyang.mohanyang.presentation.designsystem.topappbar.MnTopAppBar
-import com.pomonyang.mohanyang.presentation.screen.pomodoro.component.CategoryBox
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
 import com.pomonyang.mohanyang.presentation.util.noRippleClickable

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/time/PomodoroTimeSettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/time/PomodoroTimeSettingScreen.kt
@@ -21,10 +21,10 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mohanyang.presentation.R
+import com.pomonyang.mohanyang.presentation.component.CategoryBox
 import com.pomonyang.mohanyang.presentation.designsystem.icon.MnMediumIcon
 import com.pomonyang.mohanyang.presentation.designsystem.picker.MnWheelMinutePicker
 import com.pomonyang.mohanyang.presentation.designsystem.topappbar.MnTopAppBar
-import com.pomonyang.mohanyang.presentation.screen.pomodoro.component.CategoryBox
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.setting.SettingButton
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/TimeUtils.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/TimeUtils.kt
@@ -1,5 +1,12 @@
 package com.pomonyang.mohanyang.presentation.util
 
 import java.time.LocalTime
+import java.util.*
 
 fun LocalTime.displayAlarm(): String = "${this.hour}".padStart(2, '0') + ":" + "${this.minute}".padStart(2, '0') + " " + if (this.hour < 12) "AM" else "PM"
+
+fun Int.formatTime(): String {
+    val minutesPart = this / 60
+    val secondsPart = this % 60
+    return String.format(Locale.KOREAN, "%02d:%02d", minutesPart, secondsPart)
+}

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -37,5 +37,7 @@
     <string name="onboarding_select_alarm_title">모하냥</string>
     <string name="onboarding_select_alarm_empty">고양이를 선택하면\n딴 짓 방해알림 예시를 보여드려요</string>
     <string name="onboarding_select_alarm_time">지금</string>
-
+    <string name="focus_cat_tooltip">잘 집중하고 있는 거냥?</string>
+    <string name="exceed_cat_tooltip">이제 나랑 놀자냥?</string>
+    <string name="welcome_cat_tooltip">오랜만이다냥</string>
 </resources>


### PR DESCRIPTION
## 작업 내용

- 뽀모도르 비즈니스 로직 분리
  - 집중시간이 0초가 되면 초과시간이 늘어나게 추가
  - 초과시간이 60분이 되면 바로 휴식 페이지로 이동
  - 집중 끝내기 누르면 Home으로 이동
- CatRive / Timer 공통 컴포넌트로 분리 

## 체크리스트
- [x] 빌드 확인
- [x] 타이머가 홈으로 가도 정상 동작하는지?.. (30분 정도 확인했을 때 1초 정도의 오차가 생기긴했음)
- [x] 휴식 / 홈 이동시 백스택이 어색하지 않은지

## 동작 화면

[Screen_recording_20240815_142005.webm](https://github.com/user-attachments/assets/878a23bc-1662-45ae-9b10-8b5f0f2a688a)

> 디버그 빌드 기준 0.01초마다 집중시간 -1 하고 최대 초과시간은 600초로 임시로 넣어둔 상태

```kotlin
private val TIMER_DELAY = if (BuildConfig.DEBUG) 10L else 1_000L
private val MAX_EXCEEDED_TIME = if (BuildConfig.DEBUG) 600 else 3600
```

## 살려주세요

