### PR TITLE
[CAT-227] 토큰 갱신 로직 오류 수정

### DIFF
--- a/data/src/main/java/com/pomonyang/mohanyang/data/remote/datasource/auth/AuthRemoteDataSource.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/remote/datasource/auth/AuthRemoteDataSource.kt
@@ -3,7 +3,7 @@ package com.pomonyang.mohanyang.data.remote.datasource.auth
 import com.pomonyang.mohanyang.data.remote.model.response.TokenResponse
 
 interface AuthRemoteDataSource {
-    suspend fun login() // TODO
+    suspend fun login(deviceId: String): Result<TokenResponse>
     suspend fun logout() // TODO
     suspend fun refreshAccessToken(refreshToken: String): Result<TokenResponse>
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/remote/datasource/auth/AuthRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/remote/datasource/auth/AuthRemoteDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.pomonyang.mohanyang.data.remote.datasource.auth
 
 import com.pomonyang.mohanyang.data.remote.model.request.RefreshTokenRequest
+import com.pomonyang.mohanyang.data.remote.model.request.TokenRequest
 import com.pomonyang.mohanyang.data.remote.service.AuthService
 import javax.inject.Inject
 
@@ -8,8 +9,7 @@ internal class AuthRemoteDataSourceImpl @Inject constructor(
     private val authService: AuthService
 ) : AuthRemoteDataSource {
 
-    override suspend fun login() {
-    }
+    override suspend fun login(deviceId: String) = authService.getTokenByDeviceId(TokenRequest(deviceId))
 
     override suspend fun logout() {
     }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/remote/di/NetworkModule.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/remote/di/NetworkModule.kt
@@ -50,7 +50,7 @@ internal abstract class NetworkModule {
             Timber.tag("ApiService").d(message)
         }.apply {
             level = if (BuildConfig.DEBUG) {
-                HttpLoggingInterceptor.Level.HEADERS
+                HttpLoggingInterceptor.Level.BODY
             } else {
                 HttpLoggingInterceptor.Level.NONE
             }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/remote/di/NetworkModule.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/remote/di/NetworkModule.kt
@@ -2,6 +2,7 @@ package com.pomonyang.mohanyang.data.remote.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.mohanyang.data.BuildConfig
+import com.pomonyang.mohanyang.data.local.datastore.datasource.deviceid.DeviceIdLocalDataSource
 import com.pomonyang.mohanyang.data.local.datastore.datasource.token.TokenLocalDataSource
 import com.pomonyang.mohanyang.data.remote.datasource.auth.AuthRemoteDataSource
 import com.pomonyang.mohanyang.data.remote.interceptor.HttpRequestInterceptor
@@ -49,7 +50,7 @@ internal abstract class NetworkModule {
             Timber.tag("ApiService").d(message)
         }.apply {
             level = if (BuildConfig.DEBUG) {
-                HttpLoggingInterceptor.Level.BODY
+                HttpLoggingInterceptor.Level.HEADERS
             } else {
                 HttpLoggingInterceptor.Level.NONE
             }
@@ -65,8 +66,9 @@ internal abstract class NetworkModule {
         @Singleton
         fun provideTokenRefreshInterceptor(
             authRemoteDataSource: AuthRemoteDataSource,
-            tokenLocalDataSource: TokenLocalDataSource
-        ): TokenRefreshInterceptor = TokenRefreshInterceptor(authRemoteDataSource, tokenLocalDataSource)
+            tokenLocalDataSource: TokenLocalDataSource,
+            deviceIdLocalDataSource: DeviceIdLocalDataSource
+        ): TokenRefreshInterceptor = TokenRefreshInterceptor(authRemoteDataSource, tokenLocalDataSource, deviceIdLocalDataSource)
 
         @Provides
         @Singleton

--- a/data/src/main/java/com/pomonyang/mohanyang/data/remote/interceptor/HttpRequestInterceptor.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/remote/interceptor/HttpRequestInterceptor.kt
@@ -19,7 +19,8 @@ internal class HttpRequestInterceptor @Inject constructor(
                 .newBuilder()
                 .addHeader("Content-Type", "application/x-www-form-urlencoded")
                 .addHeader("Accept", "*/*")
-                .addHeader("Authorization", "Bearer $accessToken")
+                .removeHeader("Authorization")
+                .header("Authorization", "Bearer $accessToken")
                 .build()
         return chain.proceed(request)
     }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/remote/interceptor/TokenRefreshInterceptor.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/remote/interceptor/TokenRefreshInterceptor.kt
@@ -1,5 +1,6 @@
 package com.pomonyang.mohanyang.data.remote.interceptor
 
+import com.pomonyang.mohanyang.data.local.datastore.datasource.deviceid.DeviceIdLocalDataSource
 import com.pomonyang.mohanyang.data.local.datastore.datasource.token.TokenLocalDataSource
 import com.pomonyang.mohanyang.data.remote.datasource.auth.AuthRemoteDataSource
 import javax.inject.Inject
@@ -9,14 +10,18 @@ import okhttp3.Response
 
 internal class TokenRefreshInterceptor @Inject constructor(
     private val authRemoteDataSource: AuthRemoteDataSource,
-    private val tokenLocalDataSource: TokenLocalDataSource
+    private val tokenLocalDataSource: TokenLocalDataSource,
+    private val deviceIdLocalDataSource: DeviceIdLocalDataSource
 ) : Interceptor {
+
     override fun intercept(chain: Interceptor.Chain): Response {
         val origin = chain.request()
         val response = chain.proceed(origin)
+
         if (response.code == 401) {
-            val accessToken = runBlocking { getNewAccessToken() }
             response.close()
+
+            val accessToken = runBlocking { getNewAccessToken() }
             val request =
                 origin
                     .newBuilder()
@@ -24,18 +29,52 @@ internal class TokenRefreshInterceptor @Inject constructor(
                     .addHeader("Accept", "*/*")
                     .addHeader("Authorization", "Bearer $accessToken")
                     .build()
-            return chain.proceed(request)
+
+            val accessRefreshResponse = chain.proceed(request)
+
+            if (accessRefreshResponse.code == 400) {
+                accessRefreshResponse.close()
+
+                val refreshedToken = runBlocking { refreshAllTokensWithDeviceId() }
+
+                if (refreshedToken != null) {
+                    val refreshAllTokenRequest = origin
+                        .newBuilder()
+                        .addHeader("Content-Type", "application/x-www-form-urlencoded")
+                        .addHeader("Accept", "*/*")
+                        .addHeader("Authorization", "Bearer $refreshedToken")
+                        .build()
+
+                    return chain.proceed(refreshAllTokenRequest)
+                }
+            }
+
+            return accessRefreshResponse
         }
         return response
     }
 
     private suspend fun getNewAccessToken(): String? {
         val refreshToken = runBlocking { tokenLocalDataSource.getRefreshToken() }
-        val newAccessToken = runBlocking { authRemoteDataSource.refreshAccessToken(refreshToken) }.getOrNull()
+        val newAccessToken = runBlocking {
+            authRemoteDataSource.refreshAccessToken(refreshToken)
+        }.getOrNull()
         return newAccessToken?.let {
             tokenLocalDataSource.saveAccessToken(it.accessToken)
             tokenLocalDataSource.saveRefreshToken(it.refreshToken)
             it.accessToken
+        } ?: run {
+            authRemoteDataSource.logout()
+            null
+        }
+    }
+
+    private suspend fun refreshAllTokensWithDeviceId(): String? {
+        val deviceId = deviceIdLocalDataSource.getDeviceId()
+        return authRemoteDataSource.login(deviceId).getOrNull()?.let { tokenData ->
+            tokenLocalDataSource.saveAccessToken(tokenData.accessToken)
+            tokenLocalDataSource.saveRefreshToken(tokenData.refreshToken)
+            tokenData.accessToken
         } ?: run {
             authRemoteDataSource.logout()
             null

--- a/data/src/main/java/com/pomonyang/mohanyang/data/remote/interceptor/TokenRefreshInterceptor.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/remote/interceptor/TokenRefreshInterceptor.kt
@@ -25,9 +25,8 @@ internal class TokenRefreshInterceptor @Inject constructor(
             val request =
                 origin
                     .newBuilder()
-                    .addHeader("Content-Type", "application/x-www-form-urlencoded")
-                    .addHeader("Accept", "*/*")
-                    .addHeader("Authorization", "Bearer $accessToken")
+                    .removeHeader("Authorization")
+                    .header("Authorization", "Bearer $accessToken")
                     .build()
 
             val accessRefreshResponse = chain.proceed(request)
@@ -40,9 +39,7 @@ internal class TokenRefreshInterceptor @Inject constructor(
                 if (refreshedToken != null) {
                     val refreshAllTokenRequest = origin
                         .newBuilder()
-                        .addHeader("Content-Type", "application/x-www-form-urlencoded")
-                        .addHeader("Accept", "*/*")
-                        .addHeader("Authorization", "Bearer $refreshedToken")
+                        .removeHeader("Authorization").header("Authorization", "Bearer $refreshedToken")
                         .build()
 
                     return chain.proceed(refreshAllTokenRequest)


### PR DESCRIPTION
## 작업 내용
>  Token refresh 시, 400 오류 발생 버그 수정
- 원인 : Authorization 중복으로 들어감
- 해결: request 시  Authorization remove 처리 후 추가
> Refresh Token Expired 시 갱신 로직 추가
- /refresh 호출시 400 으로 Expired 시 전체 token 재발급 로직 추가

## 체크리스트
- [ ] 빌드 확인
- [ ] 400 오류 없는 지 확인

## 동작 화면
- 동작 변경 없음

## 테스트결과
###  app inspector test 
1.  /users/me 요청 시 200일 경우 강제로 401 오류가 발생하도록 설정함 (refresh 요청)
2. /tokens/refresh 요청 시 200일 경우 강제로 400 오류가 발생하도록 설정함 (tokens 요청 = 모든 토큰 재발급)
3. 최종 tokens 발급 후 /users/me 재요청 로직

![스크린샷 2024-08-17 오전 1 54 25](https://github.com/user-attachments/assets/7d488da4-2876-4064-9530-88df298430ba)

1. [users/me] [request] headerauthorization 확인
![스크린샷 2024-08-17 오전 1 56 24](https://github.com/user-attachments/assets/7db8b5cc-3781-4181-b5d4-f9108d2ab77b)

2. [refresh] [response] access token 확인
![스크린샷 2024-08-17 오전 1 57 16](https://github.com/user-attachments/assets/e3c35654-9b0a-47c6-a538-d5bb3ec3f7c1)

3. [tokens] 
[response] access token 확인
![스크린샷 2024-08-17 오전 1 58 17](https://github.com/user-attachments/assets/05d6a0dd-05e2-4d35-917f-d069c04b54db)

4. [users/me]  [request] headerauthorization 확인
![스크린샷 2024-08-17 오전 1 59 56](https://github.com/user-attachments/assets/20f4b2de-e37a-48cb-9c42-df9bfcceb322)
> 마지막 응답 코드는 무시해줘... mocking 어렵..
@lee-ji-hoon  테스트 결과 제출합니다
## 살려주세요

