### PR TITLE
[CAT-234] 오프라인 알림 팝업 구현

### DIFF
--- a/app/src/main/java/com/pomonyang/mohanyang/ui/MohaNyangApp.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/ui/MohaNyangApp.kt
@@ -1,18 +1,33 @@
 package com.pomonyang.mohanyang.ui
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration.Short
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.pomonyang.mohanyang.R
 import com.pomonyang.mohanyang.navigation.MohaNyangNavHost
+import com.pomonyang.mohanyang.presentation.designsystem.icon.MnXSmallIcon
 import com.pomonyang.mohanyang.presentation.designsystem.toast.MnToastSnackbarHost
+import com.pomonyang.mohanyang.presentation.designsystem.token.MnColor
+import com.pomonyang.mohanyang.presentation.designsystem.token.MnRadius
+import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
+import com.pomonyang.mohanyang.presentation.util.ThemePreviews
 import kotlinx.coroutines.launch
 
 @Composable
@@ -40,11 +55,9 @@ private fun MohaNyangApp(
     ) { innerPadding ->
 
         val isOffline by mohaNyangAppState.isOffline.collectAsStateWithLifecycle()
-
-        LaunchedEffect(isOffline) {
-            if (isOffline) snackbarHostState.showSnackbar("offline 상태입니다.")
+        if (isOffline) {
+            OfflinePopup()
         }
-
         MohaNyangNavHost(
             onShowSnackbar = { message, action ->
                 mohaNyangAppState.coroutineScope.launch {
@@ -59,4 +72,41 @@ private fun MohaNyangApp(
             modifier = Modifier.padding(innerPadding)
         )
     }
+}
+
+@Composable
+private fun OfflinePopup(
+    modifier: Modifier = Modifier
+) {
+    Popup(alignment = Alignment.TopCenter) {
+        Row(
+            modifier = modifier
+                .padding(10.dp)
+                .shadow(
+                    elevation = 6.dp,
+                    shape = RoundedCornerShape(MnRadius.max),
+                    clip = true
+                )
+                .background(
+                    color = MnColor.White,
+                    shape = RoundedCornerShape(MnRadius.max)
+                )
+                .padding(horizontal = MnSpacing.xLarge, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(5.dp)
+        ) {
+            MnXSmallIcon(resourceId = com.mohanyang.presentation.R.drawable.ic_null)
+            Text(
+                text = stringResource(R.string.offline_mode_message),
+                style = MnTheme.typography.bodySemiBold,
+                color = MnTheme.textColorScheme.secondary
+            )
+        }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun NetworkErrorMessagePreview() {
+    OfflinePopup()
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,5 +6,6 @@
     <string name="local_notification_id">local_notification_id</string>
     <string name="local_notification_title">local_notification_title</string>
     <string name="local_notification_message">local_notification_message</string>
+    <string name="offline_mode_message">오프라인 모드</string>
 
 </resources>


### PR DESCRIPTION
## 작업 내용

- 네트워크 끊긴 상태 알리는 팝업 구현

[figma-link](https://www.figma.com/design/mRt5Ig9no20lXsWCAs2QqX/%EB%BD%80%EB%AA%A8%EB%83%A5-%ED%8C%80-%EB%94%94%EC%9E%90%EC%9D%B8-Main?node-id=1460-29430&m=dev)

## 체크리스트
- [ ] 빌드 확인
- [ ] 네트워크 연결 / 끊김 상태 왔다갔다 하면서 팝업 상태 확인

## 동작 화면

[Screen_recording_20240817_002943.webm](https://github.com/user-attachments/assets/2486c673-8e7c-41fd-9eb7-600138b4e81a)

## 살려주세요

