### PR TITLE
[CAT-260] 휴식 대기 화면 최대 시간에 따른 navigation 추가

### DIFF
--- a/app/src/main/java/com/pomonyang/mohanyang/navigation/MohaNyangNavHost.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/navigation/MohaNyangNavHost.kt
@@ -16,6 +16,7 @@ import com.pomonyang.mohanyang.ui.MohaNyangAppState
 @Composable
 internal fun MohaNyangNavHost(
     onShowSnackbar: (String, Int?) -> Unit,
+    onForceGoHome: () -> Unit,
     mohaNyangAppState: MohaNyangAppState,
     modifier: Modifier = Modifier
 ) {
@@ -66,7 +67,8 @@ internal fun MohaNyangNavHost(
         pomodoroScreen(
             isNewUser = mohaNyangAppState.isNewUser,
             navHostController = mohaNyangAppState.navHostController,
-            onShowSnackbar = onShowSnackbar
+            onShowSnackbar = onShowSnackbar,
+            onForceGoHome = onForceGoHome
         )
 
         myPageScreen(navHostController = navHostController)

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/LocalNotificationReceiver.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/LocalNotificationReceiver.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @AndroidEntryPoint
 class LocalNotificationReceiver @Inject constructor() : BroadcastReceiver() {
@@ -84,8 +83,6 @@ class LocalNotificationReceiver @Inject constructor() : BroadcastReceiver() {
 
     private fun notifyMessage(context: Context, notificationId: Int, title: String = context.getString(R.string.app_name), message: String) {
         if (!context.isNotificationGranted()) return
-
-        Timber.tag("koni").d("notifyMessage > ")
 
         val notificationIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)?.apply {
             flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP

--- a/app/src/main/java/com/pomonyang/mohanyang/ui/MohaNyangApp.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/ui/MohaNyangApp.kt
@@ -3,6 +3,7 @@ package com.pomonyang.mohanyang.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Scaffold
@@ -21,8 +22,13 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.mohanyang.presentation.R as PresentationR
 import com.pomonyang.mohanyang.R
 import com.pomonyang.mohanyang.navigation.MohaNyangNavHost
+import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButton
+import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonColorType
+import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonStyles
+import com.pomonyang.mohanyang.presentation.designsystem.dialog.MnDialog
 import com.pomonyang.mohanyang.presentation.designsystem.icon.MnXSmallIcon
 import com.pomonyang.mohanyang.presentation.designsystem.toast.MnToastSnackbarHost
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnColor
@@ -58,6 +64,7 @@ private fun MohaNyangApp(
         snackbarHost = { MnToastSnackbarHost(hostState = snackbarHostState, leadingIconResourceId = snackbarIconRes) }
     ) { innerPadding ->
         val isOffline by mohaNyangAppState.isOffline.collectAsStateWithLifecycle()
+        var isForceHome by remember { mutableStateOf(false) }
         val showSnackbar: (String, Int?) -> Unit = remember {
             { message, iconRes ->
                 snackbarIconRes = iconRes
@@ -74,8 +81,27 @@ private fun MohaNyangApp(
         if (isOffline) {
             OfflinePopup()
         }
+
+        if (isForceHome) {
+            MnDialog(
+                title = stringResource(R.string.force_home_dialog_title),
+                subTitle = stringResource(R.string.force_home_dialog_subtitle),
+                positiveButton = {
+                    MnBoxButton(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = stringResource(id = PresentationR.string.confirm),
+                        onClick = { isForceHome = false },
+                        colors = MnBoxButtonColorType.tertiary,
+                        styles = MnBoxButtonStyles.medium
+                    )
+                }
+            ) {
+                isForceHome = false
+            }
+        }
         MohaNyangNavHost(
             onShowSnackbar = showSnackbar,
+            onForceGoHome = { isForceHome = true },
             mohaNyangAppState = mohaNyangAppState,
             modifier = Modifier.padding(innerPadding)
         )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,5 +7,7 @@
     <string name="local_notification_title">local_notification_title</string>
     <string name="local_notification_message">local_notification_message</string>
     <string name="offline_mode_message">오프라인 모드</string>
+    <string name="force_home_dialog_title">집중을 끝내고 돌아왔어요</string>
+    <string name="force_home_dialog_subtitle">너무 오랜 시간동안 대기화면에 머물렀어요. 더이상 집중하지 않는다고 판단한 고양이가 집사님을 홈화면으로 이동시켰어요.</string>
 
 </resources>

--- a/domain/src/main/java/com/pomonyang/mohanyang/domain/usecase/AdjustPomodoroTimeUseCase.kt
+++ b/domain/src/main/java/com/pomonyang/mohanyang/domain/usecase/AdjustPomodoroTimeUseCase.kt
@@ -4,7 +4,6 @@ import com.pomonyang.mohanyang.data.repository.pomodoro.PomodoroSettingRepositor
 import java.time.Duration
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
-import timber.log.Timber
 
 class AdjustPomodoroTimeUseCase @Inject constructor(
     private val pomodoroSettingRepository: PomodoroSettingRepository,
@@ -19,8 +18,6 @@ class AdjustPomodoroTimeUseCase @Inject constructor(
 
         val updatedFocusTime = if (isFocusTime) focusTime + adjustment else focusTime
         val updatedRestTime = if (!isFocusTime) restTime + adjustment else restTime
-
-        Timber.tag("koni").d("AdjustPomodoroTimeUseCase > $updatedFocusTime // $updatedRestTime")
 
         pomodoroSettingRepository.updatePomodoroCategoryTimes(
             categoryNo = selectedPomodoroSetting.categoryNo,

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroNavigator.kt
@@ -42,6 +42,7 @@ internal data object PomodoroRest
 
 fun NavGraphBuilder.pomodoroScreen(
     isNewUser: Boolean,
+    onForceGoHome: () -> Unit,
     onShowSnackbar: (String, Int?) -> Unit,
     navHostController: NavHostController
 ) {
@@ -124,6 +125,10 @@ fun NavGraphBuilder.pomodoroScreen(
                     navHostController.navigate(PomodoroRest) {
                         popUpTo<PomodoroRestWaiting> { inclusive = true }
                     }
+                },
+                forceGoHome = {
+                    navHostController.popBackStack()
+                    onForceGoHome()
                 },
                 onShowSnackbar = onShowSnackbar
             )

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 data class PomodoroTimerState(
     val maxFocusTime: Int = 0,
@@ -69,7 +68,6 @@ class PomodoroTimerViewModel @Inject constructor(
     override fun setInitialState(): PomodoroTimerState = PomodoroTimerState()
 
     override fun handleEvent(event: PomodoroTimerEvent) {
-        Timber.tag("koni").d("handleEvent > $event")
         when (event) {
             PomodoroTimerEvent.Init -> viewModelScope.launch {
                 val selectedPomodoroSetting = getSelectedPomodoroSettingUseCase().first().toModel()
@@ -120,7 +118,6 @@ class PomodoroTimerViewModel @Inject constructor(
                         copy(currentFocusTime = currentFocusTime + ONE_SECOND)
                     } else {
                         if (exceededTime == 0) {
-                            Timber.tag("koni").d("SendEndFocusAlarm > SendEndFocusAlarm")
                             setEffect(PomodoroTimerEffect.SendEndFocusAlarm)
                         }
                         val newExceedTime = exceededTime + ONE_SECOND

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestScreen.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalAssetLoader::class)
+
 package com.pomonyang.mohanyang.presentation.screen.pomodoro.rest
 
 import androidx.activity.compose.BackHandler
@@ -20,6 +22,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import app.rive.runtime.kotlin.core.ExperimentalAssetLoader
 import com.mohanyang.presentation.R
 import com.pomonyang.mohanyang.presentation.component.CatRive
 import com.pomonyang.mohanyang.presentation.component.CategoryBox
@@ -112,7 +115,13 @@ private fun PomodoroRestScreen(
 
         Spacer(modifier = Modifier.weight(1f))
 
-        CatRive(tooltipMessage = stringResource(id = tooltipMessage), riveResource = R.raw.cat_motion_transparent)
+        CatRive(
+            tooltipMessage = stringResource(id = tooltipMessage),
+            riveResource = R.raw.cat_motion_transparent,
+            onRiveClick = {
+                it.fireState("State Machine 1", "Click")
+            }
+        )
 
         TimerType(type = stringResource(id = R.string.rest_time), iconRes = R.drawable.ic_rest)
 

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestWaitingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestWaitingScreen.kt
@@ -40,6 +40,7 @@ fun PomodoroRestWaitingRoute(
     focusTime: Int,
     exceedTime: Int,
     goToHome: () -> Unit,
+    forceGoHome: () -> Unit,
     goToPomodoroRest: () -> Unit,
     modifier: Modifier = Modifier,
     pomodoroRestWaitingViewModel: PomodoroRestWaitingViewModel = hiltViewModel(),
@@ -51,6 +52,7 @@ fun PomodoroRestWaitingRoute(
             PomodoroRestWaitingSideEffect.GoToPomodoroSetting -> goToHome()
             is PomodoroRestWaitingSideEffect.ShowSnackbar -> onShowSnackbar(effect.message, effect.iconRes)
             PomodoroRestWaitingSideEffect.GoToPomodoroRest -> goToPomodoroRest()
+            PomodoroRestWaitingSideEffect.ForceGoPomodoroSetting -> forceGoHome()
         }
     }
 

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestWaitingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestWaitingScreen.kt
@@ -33,7 +33,6 @@ import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.DevicePreviews
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
 import com.pomonyang.mohanyang.presentation.util.formatTime
-import timber.log.Timber
 
 @Composable
 fun PomodoroRestWaitingRoute(
@@ -48,7 +47,6 @@ fun PomodoroRestWaitingRoute(
 ) {
     val state by pomodoroRestWaitingViewModel.state.collectAsStateWithLifecycle()
     pomodoroRestWaitingViewModel.effects.collectWithLifecycle { effect ->
-        Timber.tag("koni").d("effect > $effect")
         when (effect) {
             PomodoroRestWaitingSideEffect.GoToPomodoroSetting -> goToHome()
             is PomodoroRestWaitingSideEffect.ShowSnackbar -> onShowSnackbar(effect.message, effect.iconRes)

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestWaitingViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestWaitingViewModel.kt
@@ -17,7 +17,6 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 data class PomodoroRestWaitingState(
     val plusButtonSelected: Boolean = false,
@@ -59,7 +58,6 @@ class PomodoroRestWaitingViewModel @Inject constructor(
     override fun setInitialState(): PomodoroRestWaitingState = PomodoroRestWaitingState()
 
     override fun handleEvent(event: PomodoroRestWaitingEvent) {
-        Timber.tag("koni").d("handleEvent > $event")
         when (event) {
             is PomodoroRestWaitingEvent.Init -> {
                 viewModelScope.launch {

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingScreen.kt
@@ -146,7 +146,6 @@ fun PomodoroSettingScreen(
             CatRive(
                 tooltipMessage = stringResource(R.string.welcome_cat_tooltip),
                 riveResource = R.raw.cat_motion_transparent,
-                stateMachineName = "State Machine 1",
                 onRiveClick = {
                     it.fireState("State Machine 1", "Click")
                 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingScreen.kt
@@ -62,7 +62,6 @@ import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
 import com.pomonyang.mohanyang.presentation.util.noRippleClickable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import timber.log.Timber
 
 @Composable
 fun PomodoroSettingRoute(
@@ -76,7 +75,6 @@ fun PomodoroSettingRoute(
 ) {
     val state by pomodoroSettingViewModel.state.collectAsStateWithLifecycle()
     pomodoroSettingViewModel.effects.collectWithLifecycle { effect ->
-        Timber.tag("koni").d("handleEffect > $effect")
         when (effect) {
             is PomodoroSettingSideEffect.ShowSnackBar -> onShowSnackbar(effect.message, effect.iconRes)
             is PomodoroSettingSideEffect.GoTimeSetting -> goTimeSetting(effect.isFocusTime, effect.initialTime, effect.category)


### PR DESCRIPTION
## 작업 내용

- 휴식 대기 화면 60분 이상 넘어가면 강제로 Home으로 이동
   - 이때 Dialog도 보여주는 형태

> 디버그는 10초

## 체크리스트
- [x] 빌드 확인
- [x] 10초 대기했을 때 정상적으로 홈으로 가지는지

## 동작 화면

[휴식대기화면.webm](https://github.com/user-attachments/assets/1657602f-4d6e-414b-ac45-02e7512f23ce)

## 살려주세요

