### PR TITLE
[CAT-266] clickableSingle / SystemBar light 고정 / 온보딩 툴팁 디테일 수정

### DIFF
--- a/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
@@ -2,10 +2,12 @@ package com.pomonyang.mohanyang
 
 import android.app.Activity
 import android.content.IntentFilter
+import android.graphics.Color
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -79,7 +81,10 @@ class MainActivity : ComponentActivity() {
         GlobalScope.launch { pomodoroTimerRepository.savePomodoroCacheData() }
         handleSplashScreen()
         initializeFCM()
-        enableEdgeToEdge()
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT),
+            navigationBarStyle = SystemBarStyle.light(Color.TRANSPARENT, Color.TRANSPARENT)
+        )
 
         setContent {
             val coroutineScope = rememberCoroutineScope()

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/component/CatRive.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/component/CatRive.kt
@@ -32,7 +32,7 @@ import com.pomonyang.mohanyang.presentation.designsystem.tooltip.MnTooltipDefaul
 import com.pomonyang.mohanyang.presentation.designsystem.tooltip.TooltipAnchor
 import com.pomonyang.mohanyang.presentation.designsystem.tooltip.TooltipContent
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
-import com.pomonyang.mohanyang.presentation.util.debounceNoRippleClickable
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 
@@ -114,7 +114,9 @@ fun CatRive(
                 Box(
                     modifier = Modifier
                         .matchParentSize()
-                        .debounceNoRippleClickable {
+                        .clickableSingle(
+                            activeRippleEffect = false
+                        ) {
                             onRiveClick(riveView)
                         }
                 )

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/bottomsheet/MnBottomSheet.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/bottomsheet/MnBottomSheet.kt
@@ -25,7 +25,7 @@ import com.pomonyang.mohanyang.presentation.designsystem.button.select.MnSelectL
 import com.pomonyang.mohanyang.presentation.designsystem.icon.MnMediumIcon
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -90,7 +90,7 @@ private fun BottomSheetContent(
                 resourceId = R.drawable.ic_close,
                 modifier = Modifier
                     .padding(8.dp)
-                    .noRippleClickable { onCloseClick() }
+                    .clickableSingle(activeRippleEffect = false) { onCloseClick() }
             )
         }
 

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/button/common/MnPressableWrapper.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/button/common/MnPressableWrapper.kt
@@ -16,7 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.input.pointer.pointerInput
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnInteraction
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 
 @Composable
 fun MnPressableWrapper(
@@ -50,7 +50,7 @@ fun Modifier.pressClickEffect(onClick: () -> Unit) = composed {
 
     this
         .background(interactionColor)
-        .noRippleClickable { onClick() }
+        .clickableSingle(activeRippleEffect = false) { onClick() }
         .pointerInput(buttonState) {
             awaitPointerEventScope {
                 buttonState = if (buttonState == ButtonState.Pressed) {

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/button/select/MnSelectButton.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/button/select/MnSelectButton.kt
@@ -28,7 +28,7 @@ import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnStroke
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.ThemePreviews
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 
 @Composable
 fun MnSelectButton(
@@ -59,7 +59,7 @@ fun MnSelectButton(
     ) {
         Column(
             modifier = modifier
-                .noRippleClickable { onClick() },
+                .clickableSingle(activeRippleEffect = false) { onClick() },
             verticalArrangement = Arrangement.spacedBy(MnSpacing.xSmall, Alignment.CenterVertically),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/button/text/MnTextButton.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/button/text/MnTextButton.kt
@@ -23,7 +23,7 @@ import com.pomonyang.mohanyang.presentation.designsystem.button.common.MnPressab
 import com.pomonyang.mohanyang.presentation.designsystem.icon.MnMediumIcon
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.ThemePreviews
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 
 @Composable
 fun MnTextButton(
@@ -81,7 +81,7 @@ fun PreviewMnBoxButton() {
                 onClick = {}
             )
             MnTextButton(
-                modifier = Modifier.noRippleClickable { },
+                modifier = Modifier.clickableSingle(activeRippleEffect = false) { },
                 styles = MnTextButtonStyles.large,
                 text = "Button",
                 onClick = {},
@@ -91,7 +91,7 @@ fun PreviewMnBoxButton() {
             )
 
             MnTextButton(
-                modifier = Modifier.noRippleClickable { },
+                modifier = Modifier.clickableSingle(activeRippleEffect = false) { },
                 styles = MnTextButtonStyles.medium,
                 text = "Button",
                 onClick = {},

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/button/toggle/MnToggleButton.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/button/toggle/MnToggleButton.kt
@@ -19,7 +19,7 @@ import com.pomonyang.mohanyang.presentation.designsystem.button.toggle.MnToggleB
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnRadius
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.ThemePreviews
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 import kotlin.math.roundToInt
 
 @Composable
@@ -52,8 +52,7 @@ fun MnToggleButton(
                     MnTheme.iconColorScheme.disabled
                 }
             )
-            .noRippleClickable(onClick = { onCheckedChange(!isChecked) })
-
+            .clickableSingle(activeRippleEffect = false, onClick = { onCheckedChange(!isChecked) })
     ) {
         Box(
             modifier = Modifier

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/dialog/MnDialog.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/dialog/MnDialog.kt
@@ -26,7 +26,7 @@ import com.pomonyang.mohanyang.presentation.designsystem.icon.MnMediumIcon
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnRadius
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 
 @Composable
 fun MnDialog(
@@ -143,7 +143,7 @@ private fun DialogTitle(
             resourceId = R.drawable.ic_close,
             modifier = Modifier
                 .padding(8.dp)
-                .noRippleClickable { onCloseClick() }
+                .clickableSingle(activeRippleEffect = false) { onCloseClick() }
         )
     }
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelMinutePicker.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/picker/MnWheelMinutePicker.kt
@@ -46,8 +46,8 @@ import com.mohanyang.presentation.R
 import com.pomonyang.mohanyang.presentation.designsystem.icon.MnMediumIcon
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnRadius
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 import com.pomonyang.mohanyang.presentation.util.formatToMinutesAndSeconds
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
 import kotlinx.collections.immutable.PersistentList
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.launch
@@ -221,7 +221,7 @@ private fun BoxScope.WheelItemList(
                     .height(if (isCentralItem) focusItemHeight else itemHeight)
                     .padding(start = if (isCentralItem) 36.dp else 0.dp)
                     .fillMaxWidth()
-                    .noRippleClickable { onItemClick(index) },
+                    .clickableSingle(activeRippleEffect = false) { onItemClick(index) },
                 contentAlignment = Alignment.Center
             ) {
                 Text(

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/toast/MnToastSnackbarHost.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/toast/MnToastSnackbarHost.kt
@@ -32,7 +32,7 @@ import com.pomonyang.mohanyang.presentation.designsystem.token.MnRadius
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.ThemePreviews
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 import kotlinx.coroutines.launch
 import timber.log.Timber
 
@@ -75,7 +75,7 @@ fun MnToastSnackbarHost(
                 data.visuals.actionLabel?.let { label ->
                     Spacer(modifier = Modifier.padding(start = MnSpacing.small))
                     Text(
-                        modifier = Modifier.noRippleClickable {
+                        modifier = Modifier.clickableSingle(activeRippleEffect = false) {
                             data.performAction()
                         },
                         text = label,

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/tooltip/MnTooltip.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/tooltip/MnTooltip.kt
@@ -67,8 +67,8 @@ import androidx.compose.ui.window.PopupPositionProvider
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnRadius
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 import com.pomonyang.mohanyang.presentation.util.dpToPx
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
 import com.pomonyang.mohanyang.presentation.util.pxToDp
 import kotlin.math.min
 import kotlinx.coroutines.delay
@@ -242,7 +242,7 @@ fun Modifier.guideTooltip(
                         backgroundColor = MnTooltipDefaults.overlayBackgroundColor,
                         shape = ovalShape
                     )
-                    .noRippleClickable { onDismiss() }
+                    .clickableSingle(activeRippleEffect = false) { onDismiss() }
             ) {
                 MnTooltipImpl(
                     modifier = Modifier
@@ -521,7 +521,7 @@ private fun MnTopTooltipPreview() {
             Text(
                 text = "Sample",
                 modifier = Modifier
-                    .noRippleClickable { isShowTooltip = true }
+                    .clickableSingle(activeRippleEffect = false) { isShowTooltip = true }
                     .guideTooltip(
                         anchorPadding = PaddingValues(bottom = 12.dp),
                         verticalAlignment = Alignment.Top,
@@ -553,7 +553,7 @@ private fun MnBottomTooltipPreview() {
                 text = "Sample",
                 modifier = Modifier
                     .padding(start = 12.dp)
-                    .noRippleClickable { isShowTooltip = true }
+                    .clickableSingle(activeRippleEffect = false) { isShowTooltip = true }
                     .guideTooltip(
                         tooltipColors = MnTooltipDefaults.darkTooltipColors(),
                         verticalAlignment = Alignment.Bottom,

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/topappbar/MnTopAppBar.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/topappbar/MnTopAppBar.kt
@@ -23,8 +23,8 @@ import androidx.compose.ui.unit.dp
 import com.mohanyang.presentation.R
 import com.pomonyang.mohanyang.presentation.designsystem.icon.MnMediumIcon
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 import com.pomonyang.mohanyang.presentation.util.dpToPx
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
 
 @Composable
 fun MnTopAppBar(
@@ -94,7 +94,7 @@ private fun MnTopAppBarPreview() {
                 Box(
                     modifier = Modifier
                         .size(40.dp)
-                        .noRippleClickable { },
+                        .clickableSingle(activeRippleEffect = false) { },
                     contentAlignment = Alignment.Center
                 ) {
                     MnMediumIcon(
@@ -107,7 +107,7 @@ private fun MnTopAppBarPreview() {
                 Box(
                     modifier = Modifier
                         .size(40.dp)
-                        .noRippleClickable { },
+                        .clickableSingle(activeRippleEffect = false) { },
                     contentAlignment = Alignment.Center
                 ) {
                     MnMediumIcon(
@@ -133,7 +133,7 @@ private fun MnTopAppBarNotUseActionsPreview() {
                 Box(
                     modifier = Modifier
                         .size(40.dp)
-                        .noRippleClickable { },
+                        .clickableSingle(activeRippleEffect = false) { },
                     contentAlignment = Alignment.Center
                 ) {
                     MnMediumIcon(
@@ -159,7 +159,7 @@ private fun MnTopAppBarNotUseNaivigationPreview() {
                 Box(
                     modifier = Modifier
                         .size(40.dp)
-                        .noRippleClickable { },
+                        .clickableSingle(activeRippleEffect = false) { },
                     contentAlignment = Alignment.Center
                 ) {
                     MnMediumIcon(

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/mypage/MyPageScreen.kt
@@ -41,8 +41,8 @@ import com.pomonyang.mohanyang.presentation.designsystem.topappbar.MnTopAppBar
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.DevicePreviews
 import com.pomonyang.mohanyang.presentation.util.MnNotificationManager
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
 
 @Composable
 fun MyPageRoute(
@@ -199,7 +199,7 @@ fun ProfileBox(
                 shape = RoundedCornerShape(MnRadius.small)
             )
             .padding(MnSpacing.xLarge)
-            .noRippleClickable { onClick() }
+            .clickableSingle(activeRippleEffect = false) { onClick() }
     ) {
         Row(
             verticalAlignment = Alignment.CenterVertically
@@ -327,7 +327,7 @@ fun SuggestionBox(
                 shape = RoundedCornerShape(MnRadius.small)
             )
             .padding(MnSpacing.xLarge)
-            .noRippleClickable {
+            .clickableSingle(activeRippleEffect = false) {
                 onClick()
             }
     ) {

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/guide/OnboardingGuideScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/guide/OnboardingGuideScreen.kt
@@ -41,7 +41,7 @@ import com.pomonyang.mohanyang.presentation.screen.onboarding.model.OnboardingGu
 import com.pomonyang.mohanyang.presentation.screen.onboarding.model.getOnBoardingContents
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.DevicePreviews
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -210,7 +210,7 @@ private fun IndicatorDots(
 ) {
     Box(
         modifier = Modifier
-            .noRippleClickable { onClick() }
+            .clickableSingle(activeRippleEffect = false) { onClick() }
             .clip(CircleShape)
             .size(8.dp)
             .background(

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/naming/OnboardingNamingCatScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/naming/OnboardingNamingCatScreen.kt
@@ -36,8 +36,8 @@ import com.pomonyang.mohanyang.presentation.designsystem.token.MnColor
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
 import com.pomonyang.mohanyang.presentation.designsystem.topappbar.MnTopAppBar
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
 
 @Composable
 fun OnboardingNamingCatRoute(
@@ -93,7 +93,7 @@ fun OnboardingNamingCatScreen(
         modifier = modifier
             .fillMaxSize()
             .background(MnTheme.backgroundColorScheme.primary)
-            .noRippleClickable {
+            .clickableSingle(activeRippleEffect = false) {
                 focusManager.clearFocus(true)
                 keyboardController?.hide()
             }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingScreen.kt
@@ -5,7 +5,6 @@ package com.pomonyang.mohanyang.presentation.screen.pomodoro.setting
 import android.annotation.SuppressLint
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -59,8 +58,8 @@ import com.pomonyang.mohanyang.presentation.designsystem.topappbar.MnTopAppBar
 import com.pomonyang.mohanyang.presentation.model.setting.PomodoroCategoryModel
 import com.pomonyang.mohanyang.presentation.model.setting.PomodoroCategoryType
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -135,7 +134,7 @@ fun PomodoroSettingScreen(
                     Box(
                         modifier = Modifier
                             .size(40.dp)
-                            .noRippleClickable { onAction(PomodoroSettingEvent.ClickMenu) },
+                            .clickableSingle(activeRippleEffect = false) { onAction(PomodoroSettingEvent.ClickMenu) },
                         contentAlignment = Alignment.Center
                     ) {
                         MnMediumIcon(
@@ -185,7 +184,7 @@ fun PomodoroSettingScreen(
                             }
                         }
                     )
-                    .clickable { onAction(PomodoroSettingEvent.ClickCategory) }
+                    .clickableSingle { onAction(PomodoroSettingEvent.ClickCategory) }
             )
 
             TimeSetting(
@@ -231,13 +230,13 @@ private fun TimeSetting(
         horizontalArrangement = Arrangement.spacedBy(MnSpacing.medium)
     ) {
         TimeComponent(
-            modifier = Modifier.noRippleClickable { onAction(PomodoroSettingEvent.ClickFocusTime) },
+            modifier = Modifier.clickableSingle(activeRippleEffect = false) { onAction(PomodoroSettingEvent.ClickFocusTime) },
             type = stringResource(R.string.focus),
             time = stringResource(R.string.minute, pomodoroSelectedCategoryModel?.focusTime ?: 0)
         )
         TimeDivider()
         TimeComponent(
-            modifier = Modifier.noRippleClickable { onAction(PomodoroSettingEvent.ClickRestTime) },
+            modifier = Modifier.clickableSingle(activeRippleEffect = false) { onAction(PomodoroSettingEvent.ClickRestTime) },
             type = stringResource(R.string.rest),
             time = stringResource(R.string.minute, pomodoroSelectedCategoryModel?.restTime ?: 0)
         )
@@ -335,7 +334,7 @@ fun SettingButton(
             .size(88.dp)
             .clip(CircleShape)
             .background(color = backgroundColor)
-            .clickable { onClick() },
+            .clickableSingle { onClick() },
         contentAlignment = Alignment.Center
     ) {
         MnLargeIcon(

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/setting/PomodoroSettingScreen.kt
@@ -2,6 +2,7 @@
 
 package com.pomonyang.mohanyang.presentation.screen.pomodoro.setting
 
+import android.annotation.SuppressLint
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -60,6 +61,7 @@ import com.pomonyang.mohanyang.presentation.model.setting.PomodoroCategoryType
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
 import com.pomonyang.mohanyang.presentation.util.noRippleClickable
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
@@ -75,6 +77,7 @@ fun PomodoroSettingRoute(
 ) {
     val state by pomodoroSettingViewModel.state.collectAsStateWithLifecycle()
     pomodoroSettingViewModel.effects.collectWithLifecycle { effect ->
+        if (isNewUser && state.isEndOnBoardingTooltip.not()) return@collectWithLifecycle
         when (effect) {
             is PomodoroSettingSideEffect.ShowSnackBar -> onShowSnackbar(effect.message, effect.iconRes)
             is PomodoroSettingSideEffect.GoTimeSetting -> goTimeSetting(effect.isFocusTime, effect.initialTime, effect.category)
@@ -103,6 +106,7 @@ fun PomodoroSettingRoute(
     )
 }
 
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun PomodoroSettingScreen(
     onAction: (PomodoroSettingEvent) -> Unit,
@@ -113,9 +117,14 @@ fun PomodoroSettingScreen(
     val pomodoroSelectedCategoryModel by remember(state.selectedCategoryNo) {
         mutableStateOf(state.categoryList.find { it.categoryNo == state.selectedCategoryNo })
     }
-    var categoryTooltip by remember { mutableStateOf(showOnboardingTooltip) }
+    var categoryTooltip by remember { mutableStateOf(false) }
     var timeTooltip by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) {
+        delay(0.5.seconds)
+        categoryTooltip = showOnboardingTooltip
+    }
 
     Scaffold(
         modifier = modifier,

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/time/PomodoroTimeSettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/time/PomodoroTimeSettingScreen.kt
@@ -28,8 +28,8 @@ import com.pomonyang.mohanyang.presentation.model.setting.PomodoroCategoryType
 import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.setting.SettingButton
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
+import com.pomonyang.mohanyang.presentation.util.clickableSingle
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
-import com.pomonyang.mohanyang.presentation.util.noRippleClickable
 
 @Composable
 fun PomodoroTimeSettingRoute(
@@ -124,7 +124,7 @@ private fun TimeSettingTopAppBar(
             Box(
                 modifier = Modifier
                     .size(40.dp)
-                    .noRippleClickable { onActionClick() },
+                    .clickableSingle(activeRippleEffect = false) { onActionClick() },
                 contentAlignment = Alignment.Center
             ) {
                 MnMediumIcon(


### PR DESCRIPTION
## 작업 내용

- noRippleClickable / clickable 전부 `clickableSingle`로 대체
  - 일반 click으로 하니 event가 2번 3번 발행되면서 페이지 겹치는 경우가 생김
- 다크모드에서 SystemBar의 아이콘 및 텍스트들이 안보이는 문제가 있어서 수정
  - 추가로 NavigationBar쪽도 Transparent로 줘서 우리 Background 보이게 설정
- 온보딩 툴팁이 페이지가 어느정도 로드 된 시점에 보이게 수정 및 툴팁 온보딩간에 다른거 안눌리게 변경

## 체크리스트
- [x] 빌드 확인
- [x] 작업 했던 영역 중 클릭 관련 확인
- [x] 라이트 / 다크 모드  StatusBar / NavigationBar 어색한 부분 없는지
- [x] 뽀모도르 온보딩 정상적으로 랜딩 및 클릭 무시 되는지

## 동작 화면

## 살려주세요

