### PR TITLE
[CAT-282] Push 관련 API 연동

### DIFF
--- a/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
@@ -78,6 +78,7 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         handleSplashScreen()
         super.onCreate(savedInstanceState)
+
         AppInitializer.getInstance(applicationContext)
             .initializeComponent(RiveInitializer::class.java)
         GlobalScope.launch { pomodoroTimerRepository.savePomodoroCacheData() }
@@ -101,6 +102,7 @@ class MainActivity : ComponentActivity() {
                             if (it.cat.no == -1) isNewUser = true
                         }
                         pomodoroSettingRepository.fetchPomodoroSettingList()
+                        fetchNotificationState()
                         showDialog = false
                     }.onFailure {
                         showDialog = isNewUser
@@ -147,6 +149,17 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    private suspend fun fetchNotificationState() {
+        if (MnNotificationManager.isNotificationGranted(this)) {
+            with(pushAlarmRepository) {
+                subscribeNotification()
+                registerPushToken(getFcmToken())
+            }
+        } else {
+            pushAlarmRepository.unSubscribeNotification()
+        }
+    }
+
     override fun onResume() {
         super.onResume()
         MnNotificationManager.stopInterrupt(this)
@@ -181,6 +194,7 @@ class MainActivity : ComponentActivity() {
     private fun handleSplashScreen() {
         installSplashScreen().also {
             it.setOnExitAnimationListener { splashScreenViewProvider ->
+
                 val splashScreenView = splashScreenViewProvider.view
                 val startColor = ContextCompat.getColor(splashScreenView.context, R.color.splash_background)
                 val endColor = ContextCompat.getColor(splashScreenView.context, R.color.splash_delay_background)


### PR DESCRIPTION
## 작업 내용
> 디코에 질문 준거 일단 작업 해놨어 근데 이 fetch를 설정타고 오는 기준에서 보면 activity resume에서 지속적으로 fetch 해주는게 맞을 거 같긴한데 너무 비효율적일까 고민이라 onCreate 부분에만 넣어놨어 의견 주세요! 
fcm 관련한 권한 허용이라 동시성이 엄청 필요해보이는 거 같진 않아서 나는 일단 create

- push 관련 API 연동

## 체크리스트
- [ ] 빌드 확인

## 동작 화면

## 살려주세요

