### PR TITLE
[CAT-311] USE_FULL_SCREEN_INTENT 제거

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
-    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+
 
     <application
         android:name="com.pomonyang.mohanyang.MohaNyangApplication"

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/util/NotificationUtils.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/util/NotificationUtils.kt
@@ -39,7 +39,6 @@ fun Context.defaultNotification(
     .setPriority(NotificationCompat.PRIORITY_HIGH)
     .setAutoCancel(true)
     .setOnlyAlertOnce(true)
-    .setFullScreenIntent(pendingIntent, true)
     .setCategory(NotificationCompat.CATEGORY_MESSAGE)
     .setGroup(getString(R.string.channel_group_name))
 


### PR DESCRIPTION
## 작업 내용
- 심의로 인한 USE_FULL_SCREEN_INTENT 제거
- 알림 full screen intent 제거

> 관련 내용
https://developer.android.com/develop/ui/views/notifications?hl=ko

![image](https://github.com/user-attachments/assets/81d66251-6f2f-4390-96f5-e6214332a745)

2,3번 조건이 만족하기 때문에 제거해도 동작에 이상이 없었음


## 체크리스트
- [x] 빌드 확인
- [x] 백/포그라운드 헤드업 알람 확인

## 동작 화면

## 살려주세요

