### PR TITLE
[CAT-313] Timer Service 구현 및 SharedViewModel 관리

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
 
 
     <application
@@ -66,7 +69,14 @@
             </intent-filter>
         </service>
 
-        <service android:name=".presentation.util.PomodoroTimerService" />
+        <service
+            android:name=".presentation.util.PomodoroTimerService"
+            android:foregroundServiceType="specialUse">
+            <meta-data
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="timer_running_in_background" />
+        </service>
+
 
     </application>
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -66,6 +66,8 @@
             </intent-filter>
         </service>
 
+        <service android:name=".presentation.util.PomodoroTimerService" />
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
@@ -166,7 +166,7 @@ class MainActivity : ComponentActivity() {
     }
 
     override fun onDestroy() {
-        GlobalScope.launch { pomodoroTimerRepository.updatePomodoroDone() }
+        GlobalScope.launch { pomodoroTimerRepository.updateRecentPomodoroDone() }
         super.onDestroy()
     }
 

--- a/app/src/main/java/com/pomonyang/mohanyang/di/ServiceModule.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/di/ServiceModule.kt
@@ -1,0 +1,37 @@
+package com.pomonyang.mohanyang.di
+
+import android.app.NotificationManager
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import com.pomonyang.mohanyang.R
+import com.pomonyang.mohanyang.presentation.di.PomodoroNotification
+import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.POMODORO_NOTIFICATION_CHANNEL_ID
+import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.POMODORO_NOTIFICATION_ID
+import com.pomonyang.mohanyang.ui.ServiceHelper
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.android.scopes.ServiceScoped
+
+@Module
+@InstallIn(ServiceModule::class)
+internal object ServiceModule {
+
+    @Provides
+    @PomodoroNotification
+    @ServiceScoped
+    fun provideNotificationBuilder(
+        @ApplicationContext context: Context
+    ): NotificationCompat.Builder = NotificationCompat.Builder(context, POMODORO_NOTIFICATION_CHANNEL_ID)
+        .setContentTitle(context.getString(R.string.app_name))
+        .setSmallIcon(R.drawable.ic_app_notification)
+        .setOngoing(true)
+        .setContentIntent(ServiceHelper.clickPendingIntent(context, POMODORO_NOTIFICATION_ID))
+
+    @Provides
+    @ServiceScoped
+    fun provideNotificationManager(
+        @ApplicationContext context: Context
+    ): NotificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+}

--- a/app/src/main/java/com/pomonyang/mohanyang/di/ServiceModule.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/di/ServiceModule.kt
@@ -11,11 +11,12 @@ import com.pomonyang.mohanyang.ui.ServiceHelper
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ServiceComponent
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.android.scopes.ServiceScoped
 
 @Module
-@InstallIn(ServiceModule::class)
+@InstallIn(ServiceComponent::class)
 internal object ServiceModule {
 
     @Provides

--- a/app/src/main/java/com/pomonyang/mohanyang/navigation/MohaNyangNavHost.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/navigation/MohaNyangNavHost.kt
@@ -9,7 +9,7 @@ import androidx.navigation.compose.NavHost
 import com.pomonyang.mohanyang.presentation.screen.mypage.myPageScreen
 import com.pomonyang.mohanyang.presentation.screen.onboarding.Onboarding
 import com.pomonyang.mohanyang.presentation.screen.onboarding.onboardingScreen
-import com.pomonyang.mohanyang.presentation.screen.pomodoro.Pomodoro
+import com.pomonyang.mohanyang.presentation.screen.pomodoro.Home
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.pomodoroScreen
 import com.pomonyang.mohanyang.ui.MohaNyangAppState
 
@@ -26,7 +26,7 @@ internal fun MohaNyangNavHost(
     val startDestination: Any = if (mohaNyangAppState.isNewUser) {
         Onboarding
     } else {
-        Pomodoro(false)
+        Home(false)
     }
 
     val slideDuration = 500

--- a/app/src/main/java/com/pomonyang/mohanyang/navigation/MohaNyangNavHost.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/navigation/MohaNyangNavHost.kt
@@ -6,10 +6,11 @@ import androidx.compose.animation.core.tween
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
+import com.pomonyang.mohanyang.presentation.screen.home.Home
+import com.pomonyang.mohanyang.presentation.screen.home.homeScreen
 import com.pomonyang.mohanyang.presentation.screen.mypage.myPageScreen
 import com.pomonyang.mohanyang.presentation.screen.onboarding.Onboarding
 import com.pomonyang.mohanyang.presentation.screen.onboarding.onboardingScreen
-import com.pomonyang.mohanyang.presentation.screen.pomodoro.Home
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.pomodoroScreen
 import com.pomonyang.mohanyang.ui.MohaNyangAppState
 
@@ -26,7 +27,7 @@ internal fun MohaNyangNavHost(
     val startDestination: Any = if (mohaNyangAppState.isNewUser) {
         Onboarding
     } else {
-        Home(false)
+        Home
     }
 
     val slideDuration = 500
@@ -65,11 +66,16 @@ internal fun MohaNyangNavHost(
             onShowSnackbar = onShowSnackbar
         )
 
-        pomodoroScreen(
+        homeScreen(
             isNewUser = mohaNyangAppState.isNewUser,
             navHostController = mohaNyangAppState.navHostController,
+            onShowSnackbar = onShowSnackbar
+        )
+
+        pomodoroScreen(
+            onForceGoHome = onForceGoHome,
             onShowSnackbar = onShowSnackbar,
-            onForceGoHome = onForceGoHome
+            navHostController = mohaNyangAppState.navHostController
         )
 
         myPageScreen(

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/LocalNotificationReceiver.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/LocalNotificationReceiver.kt
@@ -1,7 +1,6 @@
 package com.pomonyang.mohanyang.notification
 
 import android.app.NotificationManager
-import android.app.PendingIntent
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -13,8 +12,9 @@ import com.pomonyang.mohanyang.notification.util.isNotificationGranted
 import com.pomonyang.mohanyang.notification.util.summaryNotification
 import com.pomonyang.mohanyang.presentation.model.cat.CatType
 import com.pomonyang.mohanyang.presentation.util.MnNotificationManager
+import com.pomonyang.mohanyang.ui.ServiceHelper
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.*
+import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -84,17 +84,7 @@ class LocalNotificationReceiver @Inject constructor() : BroadcastReceiver() {
     private fun notifyMessage(context: Context, notificationId: Int, title: String = context.getString(R.string.app_name), message: String) {
         if (!context.isNotificationGranted()) return
 
-        val notificationIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)?.apply {
-            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
-        }
-
-        val pendingIntent =
-            PendingIntent.getActivity(
-                context,
-                notificationId,
-                notificationIntent,
-                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
-            )
+        val pendingIntent = ServiceHelper.clickPendingIntent(context, notificationId)
 
         val notification =
             context.defaultNotification(pendingIntent)

--- a/app/src/main/java/com/pomonyang/mohanyang/ui/ServiceHelper.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/ui/ServiceHelper.kt
@@ -1,0 +1,25 @@
+package com.pomonyang.mohanyang.ui
+
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+
+object ServiceHelper {
+
+    private const val FLAG = PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+
+    fun clickPendingIntent(
+        context: Context,
+        requestCode: Int
+    ): PendingIntent {
+        val notificationIntent = context.packageManager.getLaunchIntentForPackage(context.packageName)?.apply {
+            flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_SINGLE_TOP
+        }
+        return PendingIntent.getActivity(
+            context,
+            requestCode,
+            notificationIntent,
+            FLAG
+        )
+    }
+}

--- a/data/src/main/java/com/pomonyang/mohanyang/data/local/room/dao/PomodoroTimerDao.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/local/room/dao/PomodoroTimerDao.kt
@@ -13,19 +13,8 @@ interface PomodoroTimerDao {
     @Query("SELECT * FROM pomodoro_timer")
     suspend fun getAllPomodoroTimers(): List<PomodoroTimerEntity>
 
-    @Query(
-        """
-    SELECT * 
-    FROM pomodoro_timer 
-    WHERE focusTimeId = (
-        SELECT focusTimeId 
-        FROM pomodoro_timer 
-        ORDER BY ROWID DESC 
-        LIMIT 1
-    )
-    """
-    )
-    fun getCurrentTimerEntity(): Flow<PomodoroTimerEntity?>
+    @Query("SELECT *FROM pomodoro_timer WHERE focusTimeId =:timerId")
+    fun getCurrentTimer(timerId: String): Flow<PomodoroTimerEntity?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertPomodoroSettingData(pomodoroTimerEntity: PomodoroTimerEntity)

--- a/data/src/main/java/com/pomonyang/mohanyang/data/local/room/dao/PomodoroTimerDao.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/local/room/dao/PomodoroTimerDao.kt
@@ -5,6 +5,7 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import com.pomonyang.mohanyang.data.local.room.enitity.PomodoroTimerEntity
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface PomodoroTimerDao {
@@ -12,14 +13,50 @@ interface PomodoroTimerDao {
     @Query("SELECT * FROM pomodoro_timer")
     suspend fun getAllPomodoroTimers(): List<PomodoroTimerEntity>
 
+    @Query(
+        """
+    SELECT * 
+    FROM pomodoro_timer 
+    WHERE focusTimeId = (
+        SELECT focusTimeId 
+        FROM pomodoro_timer 
+        ORDER BY ROWID DESC 
+        LIMIT 1
+    )
+    """
+    )
+    fun getCurrentTimerEntity(): Flow<PomodoroTimerEntity?>
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertPomodoroSettingData(pomodoroTimerEntity: PomodoroTimerEntity)
 
-    @Query("UPDATE pomodoro_timer SET focusedTime = :focusedTime WHERE focusTimeId = (SELECT focusTimeId FROM pomodoro_timer ORDER BY ROWID DESC LIMIT 1)")
-    suspend fun updateFocusedTime(focusedTime: Int)
+    @Query(
+        """
+            UPDATE pomodoro_timer 
+            SET focusedTime = focusedTime + 1 
+            WHERE focusTimeId = (
+                SELECT focusTimeId 
+                FROM pomodoro_timer 
+                ORDER BY ROWID DESC 
+                LIMIT 1
+            )
+        """
+    )
+    suspend fun incrementFocusedTime()
 
-    @Query("UPDATE pomodoro_timer SET restedTime = :restedTime WHERE focusTimeId = (SELECT focusTimeId FROM pomodoro_timer ORDER BY ROWID DESC LIMIT 1)")
-    suspend fun updateRestedTime(restedTime: Int)
+    @Query(
+        """
+            UPDATE pomodoro_timer 
+            SET restedTime = restedTime + 1 
+            WHERE focusTimeId = (
+                SELECT focusTimeId 
+                FROM pomodoro_timer 
+                ORDER BY ROWID DESC 
+                LIMIT 1
+            )
+        """
+    )
+    suspend fun incrementRestTime()
 
     @Query("UPDATE pomodoro_timer SET doneAt = :doneAt WHERE focusTimeId = (SELECT focusTimeId FROM pomodoro_timer ORDER BY ROWID DESC LIMIT 1)")
     suspend fun updateDoneAt(doneAt: String)

--- a/data/src/main/java/com/pomonyang/mohanyang/data/local/room/dao/PomodoroTimerDao.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/local/room/dao/PomodoroTimerDao.kt
@@ -14,7 +14,7 @@ interface PomodoroTimerDao {
     suspend fun getAllPomodoroTimers(): List<PomodoroTimerEntity>
 
     @Query("SELECT *FROM pomodoro_timer WHERE focusTimeId =:timerId")
-    fun getCurrentTimer(timerId: String): Flow<PomodoroTimerEntity?>
+    fun getTimer(timerId: String): Flow<PomodoroTimerEntity?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertPomodoroSettingData(pomodoroTimerEntity: PomodoroTimerEntity)
@@ -47,9 +47,15 @@ interface PomodoroTimerDao {
     )
     suspend fun incrementRestTime()
 
+    @Query("UPDATE pomodoro_timer SET doneAt = :doneAt WHERE focusTimeId = :focusTimerId")
+    suspend fun updateDoneAt(doneAt: String, focusTimerId: String)
+
     @Query("UPDATE pomodoro_timer SET doneAt = :doneAt WHERE focusTimeId = (SELECT focusTimeId FROM pomodoro_timer ORDER BY ROWID DESC LIMIT 1)")
-    suspend fun updateDoneAt(doneAt: String)
+    suspend fun updateDoneAtRecentPomodoro(doneAt: String)
 
     @Query("DELETE FROM pomodoro_timer")
     suspend fun deletePomodoroTimerAll()
+
+    @Query("DELETE FROM pomodoro_timer WHERE focusTimeId = :focusTimeId")
+    suspend fun deletePomodoroTimer(focusTimeId: String)
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/local/room/enitity/PomodoroTimerEntity.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/local/room/enitity/PomodoroTimerEntity.kt
@@ -2,12 +2,11 @@ package com.pomonyang.mohanyang.data.local.room.enitity
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
-import java.util.*
 
 @Entity(tableName = "pomodoro_timer")
 data class PomodoroTimerEntity(
     @PrimaryKey
-    val focusTimeId: String = UUID.randomUUID().toString(),
+    val focusTimeId: String,
     val focusedTime: Int = 0,
     val restedTime: Int = 0,
     val doneAt: String = "",

--- a/data/src/main/java/com/pomonyang/mohanyang/data/local/room/enitity/PomodoroTimerEntity.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/local/room/enitity/PomodoroTimerEntity.kt
@@ -4,6 +4,7 @@ import androidx.room.Entity
 import androidx.room.PrimaryKey
 import com.pomonyang.mohanyang.data.local.room.util.formatDurationToMinutesString
 import com.pomonyang.mohanyang.data.remote.model.request.PomodoroTimerRequest
+import com.pomonyang.mohanyang.data.repository.util.getCurrentIsoInstant
 
 @Entity(tableName = "pomodoro_timer")
 data class PomodoroTimerEntity(
@@ -20,5 +21,5 @@ fun PomodoroTimerEntity.toRequestModel() = PomodoroTimerRequest(
     categoryNo = categoryNo,
     focusedTime = focusedTime.formatDurationToMinutesString(),
     restedTime = restedTime.formatDurationToMinutesString(),
-    doneAt = doneAt
+    doneAt = doneAt.ifEmpty { getCurrentIsoInstant() }
 )

--- a/data/src/main/java/com/pomonyang/mohanyang/data/local/room/enitity/PomodoroTimerEntity.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/local/room/enitity/PomodoroTimerEntity.kt
@@ -2,6 +2,8 @@ package com.pomonyang.mohanyang.data.local.room.enitity
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import com.pomonyang.mohanyang.data.local.room.util.formatDurationToMinutesString
+import com.pomonyang.mohanyang.data.remote.model.request.PomodoroTimerRequest
 
 @Entity(tableName = "pomodoro_timer")
 data class PomodoroTimerEntity(
@@ -11,4 +13,12 @@ data class PomodoroTimerEntity(
     val restedTime: Int = 0,
     val doneAt: String = "",
     val categoryNo: Int
+)
+
+fun PomodoroTimerEntity.toRequestModel() = PomodoroTimerRequest(
+    clientFocusTimeId = focusTimeId,
+    categoryNo = categoryNo,
+    focusedTime = focusedTime.formatDurationToMinutesString(),
+    restedTime = restedTime.formatDurationToMinutesString(),
+    doneAt = doneAt
 )

--- a/data/src/main/java/com/pomonyang/mohanyang/data/local/room/util/TimeUtils.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/local/room/util/TimeUtils.kt
@@ -1,0 +1,5 @@
+package com.pomonyang.mohanyang.data.local.room.util
+
+import java.time.Duration
+
+fun Int.formatDurationToMinutesString(): String = Duration.ofMinutes((this / 60).toLong()).toString()

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/pomodoro/PomodoroTimerRepository.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/pomodoro/PomodoroTimerRepository.kt
@@ -7,7 +7,6 @@ interface PomodoroTimerRepository {
     suspend fun insertPomodoroTimerInitData(categoryNo: Int, pomodoroTimerId: String)
     suspend fun incrementFocusedTime()
     suspend fun incrementRestedTime()
-    suspend fun updatePomodoroDone(pomodoroTimerId: String)
     suspend fun updateRecentPomodoroDone()
     suspend fun savePomodoroData(pomodoroTimerId: String)
     suspend fun savePomodoroCacheData()

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/pomodoro/PomodoroTimerRepository.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/pomodoro/PomodoroTimerRepository.kt
@@ -4,10 +4,10 @@ import com.pomonyang.mohanyang.data.local.room.enitity.PomodoroTimerEntity
 import kotlinx.coroutines.flow.Flow
 
 interface PomodoroTimerRepository {
-    suspend fun insertPomodoroTimerInitData(categoryNo: Int)
+    suspend fun insertPomodoroTimerInitData(categoryNo: Int, focusTimeId: String)
     suspend fun incrementFocusedTime()
     suspend fun incrementRestedTime()
     suspend fun updatePomodoroDone()
     suspend fun savePomodoroCacheData()
-    fun getPomodoroTimer(): Flow<PomodoroTimerEntity?>
+    fun getPomodoroTimer(timerId: String): Flow<PomodoroTimerEntity?>
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/pomodoro/PomodoroTimerRepository.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/pomodoro/PomodoroTimerRepository.kt
@@ -1,9 +1,13 @@
 package com.pomonyang.mohanyang.data.repository.pomodoro
 
+import com.pomonyang.mohanyang.data.local.room.enitity.PomodoroTimerEntity
+import kotlinx.coroutines.flow.Flow
+
 interface PomodoroTimerRepository {
     suspend fun insertPomodoroTimerInitData(categoryNo: Int)
-    suspend fun updateFocusTime(focusedTime: Int)
-    suspend fun updateRestedTime(restedTime: Int)
+    suspend fun incrementFocusedTime()
+    suspend fun incrementRestedTime()
     suspend fun updatePomodoroDone()
     suspend fun savePomodoroCacheData()
+    fun getPomodoroTimer(): Flow<PomodoroTimerEntity?>
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/pomodoro/PomodoroTimerRepository.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/pomodoro/PomodoroTimerRepository.kt
@@ -4,10 +4,12 @@ import com.pomonyang.mohanyang.data.local.room.enitity.PomodoroTimerEntity
 import kotlinx.coroutines.flow.Flow
 
 interface PomodoroTimerRepository {
-    suspend fun insertPomodoroTimerInitData(categoryNo: Int, focusTimeId: String)
+    suspend fun insertPomodoroTimerInitData(categoryNo: Int, pomodoroTimerId: String)
     suspend fun incrementFocusedTime()
     suspend fun incrementRestedTime()
-    suspend fun updatePomodoroDone()
+    suspend fun updatePomodoroDone(pomodoroTimerId: String)
+    suspend fun updateRecentPomodoroDone()
+    suspend fun savePomodoroData(pomodoroTimerId: String)
     suspend fun savePomodoroCacheData()
     fun getPomodoroTimer(timerId: String): Flow<PomodoroTimerEntity?>
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/pomodoro/PomodoroTimerRepositoryImpl.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/pomodoro/PomodoroTimerRepositoryImpl.kt
@@ -15,9 +15,10 @@ internal class PomodoroTimerRepositoryImpl @Inject constructor(
     private val mohaNyangService: MohaNyangService
 ) : PomodoroTimerRepository {
 
-    override suspend fun insertPomodoroTimerInitData(categoryNo: Int) {
+    override suspend fun insertPomodoroTimerInitData(categoryNo: Int, focusTimeId: String) {
         pomodoroTimerDao.insertPomodoroSettingData(
             PomodoroTimerEntity(
+                focusTimeId = focusTimeId,
                 categoryNo = categoryNo
             )
         )
@@ -53,7 +54,7 @@ internal class PomodoroTimerRepositoryImpl @Inject constructor(
         }
     }
 
-    override fun getPomodoroTimer(): Flow<PomodoroTimerEntity?> = pomodoroTimerDao.getCurrentTimerEntity()
+    override fun getPomodoroTimer(timerId: String): Flow<PomodoroTimerEntity?> = pomodoroTimerDao.getCurrentTimer(timerId)
 
     private fun Int.toDurationString(): String = Duration.ofMinutes((this / 60).toLong()).toString()
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/pomodoro/PomodoroTimerRepositoryImpl.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/pomodoro/PomodoroTimerRepositoryImpl.kt
@@ -8,6 +8,7 @@ import java.time.Duration
 import java.time.Instant
 import java.time.format.DateTimeFormatter
 import javax.inject.Inject
+import kotlinx.coroutines.flow.Flow
 
 internal class PomodoroTimerRepositoryImpl @Inject constructor(
     private val pomodoroTimerDao: PomodoroTimerDao,
@@ -22,12 +23,12 @@ internal class PomodoroTimerRepositoryImpl @Inject constructor(
         )
     }
 
-    override suspend fun updateFocusTime(focusedTime: Int) {
-        pomodoroTimerDao.updateFocusedTime(focusedTime)
+    override suspend fun incrementFocusedTime() {
+        pomodoroTimerDao.incrementFocusedTime()
     }
 
-    override suspend fun updateRestedTime(restedTime: Int) {
-        pomodoroTimerDao.updateRestedTime(restedTime)
+    override suspend fun incrementRestedTime() {
+        pomodoroTimerDao.incrementRestTime()
     }
 
     override suspend fun updatePomodoroDone() {
@@ -51,6 +52,8 @@ internal class PomodoroTimerRepositoryImpl @Inject constructor(
             pomodoroTimerDao.deletePomodoroTimerAll()
         }
     }
+
+    override fun getPomodoroTimer(): Flow<PomodoroTimerEntity?> = pomodoroTimerDao.getCurrentTimerEntity()
 
     private fun Int.toDurationString(): String = Duration.ofMinutes((this / 60).toLong()).toString()
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/pomodoro/PomodoroTimerRepositoryImpl.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/pomodoro/PomodoroTimerRepositoryImpl.kt
@@ -45,10 +45,9 @@ internal class PomodoroTimerRepositoryImpl @Inject constructor(
                     categoryNo = pomodoro.categoryNo,
                     focusedTime = pomodoro.focusedTime.toDurationString(),
                     restedTime = pomodoro.restedTime.toDurationString(),
-                    doneAt = pomodoro.doneAt
+                    doneAt = pomodoro.doneAt.ifBlank { DateTimeFormatter.ISO_INSTANT.format(Instant.now()) }
                 )
             }
-
         mohaNyangService.saveFocusTime(pomodoroList).onSuccess {
             pomodoroTimerDao.deletePomodoroTimerAll()
         }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/util/TimerUtil.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/util/TimerUtil.kt
@@ -1,0 +1,6 @@
+package com.pomonyang.mohanyang.data.repository.util
+
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
+internal fun getCurrentIsoInstant(): String = DateTimeFormatter.ISO_INSTANT.format(Instant.now())

--- a/domain/src/main/java/com/pomonyang/mohanyang/domain/usecase/InsertPomodoroInitialDataUseCase.kt
+++ b/domain/src/main/java/com/pomonyang/mohanyang/domain/usecase/InsertPomodoroInitialDataUseCase.kt
@@ -1,0 +1,16 @@
+package com.pomonyang.mohanyang.domain.usecase
+
+import com.pomonyang.mohanyang.data.repository.pomodoro.PomodoroTimerRepository
+import javax.inject.Inject
+import kotlinx.coroutines.flow.first
+
+class InsertPomodoroInitialDataUseCase @Inject constructor(
+    private val pomodoroTimerRepository: PomodoroTimerRepository,
+    private val getSelectedPomodoroSettingUseCase: GetSelectedPomodoroSettingUseCase
+) {
+
+    suspend operator fun invoke(focusTimeId: String) {
+        val selectedPomodoroSetting = getSelectedPomodoroSettingUseCase().first().categoryNo
+        pomodoroTimerRepository.insertPomodoroTimerInitData(selectedPomodoroSetting, focusTimeId)
+    }
+}

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/di/Qualifier.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/di/Qualifier.kt
@@ -1,0 +1,7 @@
+package com.pomonyang.mohanyang.presentation.di
+
+import javax.inject.Qualifier
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class PomodoroNotification

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/PomodoroConstants.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/PomodoroConstants.kt
@@ -4,7 +4,7 @@ import com.mohanyang.presentation.BuildConfig
 
 object PomodoroConstants {
     val TIMER_DELAY = if (BuildConfig.DEBUG) 10L else 1_000L
-    val MAX_EXCEEDED_TIME = if (BuildConfig.DEBUG) 600 else 3600
+    val MAX_EXCEEDED_TIME = if (BuildConfig.DEBUG) 60 else 3600
     const val MAX_FOCUS_MINUTES = 60
     const val MAX_REST_MINUTES = 30
     const val MIN_FOCUS_MINUTES = 10

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/PomodoroConstants.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/PomodoroConstants.kt
@@ -11,4 +11,7 @@ object PomodoroConstants {
     const val MIN_REST_MINUTES = 5
     const val ONE_SECOND = 1
     const val DEFAULT_TIME = "00:00"
+    const val POMODORO_NOTIFICATION_CHANNEL_ID = "pomodoro_notification_channel_id"
+    const val POMODORO_NOTIFICATION_CHANNEL_NAME = "pomodoro_notification_channel_name"
+    const val POMODORO_NOTIFICATION_ID = 1
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/HomeNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/HomeNavigator.kt
@@ -1,0 +1,83 @@
+package com.pomonyang.mohanyang.presentation.screen.home
+
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.composable
+import androidx.navigation.navigation
+import androidx.navigation.toRoute
+import com.pomonyang.mohanyang.presentation.screen.home.setting.PomodoroSettingRoute
+import com.pomonyang.mohanyang.presentation.screen.home.time.PomodoroTimeSettingRoute
+import com.pomonyang.mohanyang.presentation.screen.mypage.MyPage
+import com.pomonyang.mohanyang.presentation.screen.pomodoro.Pomodoro
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object Home
+
+@Serializable
+internal data object PomodoroSetting
+
+@Serializable
+internal data class TimeSetting(
+    val isFocusTime: Boolean,
+    val initialTime: Int,
+    val categoryName: String
+)
+
+fun NavGraphBuilder.homeScreen(
+    isNewUser: Boolean,
+    onShowSnackbar: (String, Int?) -> Unit,
+    navHostController: NavHostController
+) {
+    navigation<Home>(
+        startDestination = PomodoroSetting
+    ) {
+        val slideDuration = 500
+
+        composable<PomodoroSetting>(
+            popEnterTransition = {
+                EnterTransition.None
+            }
+        ) {
+            PomodoroSettingRoute(
+                isNewUser = isNewUser,
+                onShowSnackbar = onShowSnackbar,
+                goTimeSetting = { isFocusTime, initialTime, categoryName ->
+                    navHostController.navigate(
+                        TimeSetting(isFocusTime, initialTime, categoryName)
+                    )
+                },
+                goToPomodoro = {
+                    navHostController.navigate(Pomodoro)
+                },
+                goToMyPage = {
+                    navHostController.navigate(MyPage)
+                }
+            )
+        }
+
+        composable<TimeSetting>(
+            enterTransition = {
+                slideInVertically(tween(slideDuration), initialOffsetY = { it })
+            },
+            exitTransition = {
+                slideOutVertically(tween(slideDuration), targetOffsetY = { it })
+            }
+
+        ) { backStackEntry ->
+            val routeData = backStackEntry.toRoute<TimeSetting>()
+            PomodoroTimeSettingRoute(
+                isFocusTime = routeData.isFocusTime,
+                initialSettingTime = routeData.initialTime,
+                categoryName = routeData.categoryName,
+                onShowSnackbar = onShowSnackbar
+            ) {
+                navHostController.popBackStack()
+            }
+        }
+    }
+}

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/setting/PomodoroSettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/setting/PomodoroSettingScreen.kt
@@ -1,6 +1,7 @@
 package com.pomonyang.mohanyang.presentation.screen.home.setting
 
 import android.annotation.SuppressLint
+import android.content.Context
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -32,6 +33,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -59,6 +61,7 @@ import com.pomonyang.mohanyang.presentation.model.setting.PomodoroCategoryType
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.clickableSingle
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
+import com.pomonyang.mohanyang.presentation.util.stopTimer
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -75,6 +78,7 @@ fun PomodoroSettingRoute(
 ) {
     val state by pomodoroSettingViewModel.state.collectAsStateWithLifecycle()
     val catMessage = remember(state.cat.type) { state.cat.type.getRandomMessage() }
+    val context = LocalContext.current
     pomodoroSettingViewModel.effects.collectWithLifecycle { effect ->
         if (isNewUser && state.isEndOnBoardingTooltip.not()) return@collectWithLifecycle
         when (effect) {
@@ -87,6 +91,7 @@ fun PomodoroSettingRoute(
 
     LaunchedEffect(Unit) {
         pomodoroSettingViewModel.handleEvent(PomodoroSettingEvent.Init)
+        stopAllTimer(context)
     }
 
     if (state.showCategoryBottomSheet) {
@@ -104,6 +109,11 @@ fun PomodoroSettingRoute(
         modifier = modifier,
         showOnboardingTooltip = isNewUser && state.isEndOnBoardingTooltip.not()
     )
+}
+
+private fun stopAllTimer(context: Context) {
+    context.stopTimer(false)
+    context.stopTimer(true)
 }
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/setting/PomodoroSettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/setting/PomodoroSettingScreen.kt
@@ -59,6 +59,7 @@ import com.pomonyang.mohanyang.presentation.model.cat.CatType
 import com.pomonyang.mohanyang.presentation.model.setting.PomodoroCategoryModel
 import com.pomonyang.mohanyang.presentation.model.setting.PomodoroCategoryType
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
+import com.pomonyang.mohanyang.presentation.util.MnNotificationManager
 import com.pomonyang.mohanyang.presentation.util.clickableSingle
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
 import com.pomonyang.mohanyang.presentation.util.stopTimer
@@ -91,7 +92,7 @@ fun PomodoroSettingRoute(
 
     LaunchedEffect(Unit) {
         pomodoroSettingViewModel.handleEvent(PomodoroSettingEvent.Init)
-        stopAllTimer(context)
+        stopAllNotification(context)
     }
 
     if (state.showCategoryBottomSheet) {
@@ -111,9 +112,10 @@ fun PomodoroSettingRoute(
     )
 }
 
-private fun stopAllTimer(context: Context) {
+private fun stopAllNotification(context: Context) {
     context.stopTimer(false)
     context.stopTimer(true)
+    MnNotificationManager.stopInterrupt(context)
 }
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/setting/PomodoroSettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/setting/PomodoroSettingScreen.kt
@@ -1,4 +1,4 @@
-package com.pomonyang.mohanyang.presentation.screen.pomodoro.setting
+package com.pomonyang.mohanyang.presentation.screen.home.setting
 
 import android.annotation.SuppressLint
 import androidx.annotation.DrawableRes

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/setting/PomodoroSettingViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/setting/PomodoroSettingViewModel.kt
@@ -1,4 +1,4 @@
-package com.pomonyang.mohanyang.presentation.screen.pomodoro.setting
+package com.pomonyang.mohanyang.presentation.screen.home.setting
 
 import androidx.annotation.DrawableRes
 import androidx.lifecycle.viewModelScope

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/time/PomodoroTimeSettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/time/PomodoroTimeSettingScreen.kt
@@ -1,4 +1,4 @@
-package com.pomonyang.mohanyang.presentation.screen.pomodoro.time
+package com.pomonyang.mohanyang.presentation.screen.home.time
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -26,7 +26,7 @@ import com.pomonyang.mohanyang.presentation.designsystem.picker.MnWheelMinutePic
 import com.pomonyang.mohanyang.presentation.designsystem.topappbar.MnTopAppBar
 import com.pomonyang.mohanyang.presentation.model.setting.PomodoroCategoryType
 import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants
-import com.pomonyang.mohanyang.presentation.screen.pomodoro.setting.SettingButton
+import com.pomonyang.mohanyang.presentation.screen.home.setting.SettingButton
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.clickableSingle
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/time/PomodoroTimeSettingViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/time/PomodoroTimeSettingViewModel.kt
@@ -1,4 +1,4 @@
-package com.pomonyang.mohanyang.presentation.screen.pomodoro.time
+package com.pomonyang.mohanyang.presentation.screen.home.time
 
 import androidx.lifecycle.viewModelScope
 import com.pomonyang.mohanyang.data.repository.pomodoro.PomodoroSettingRepository

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/OnboardingNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/OnboardingNavigator.kt
@@ -7,10 +7,10 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import androidx.navigation.toRoute
 import com.pomonyang.mohanyang.presentation.model.cat.CatType
+import com.pomonyang.mohanyang.presentation.screen.home.Home
 import com.pomonyang.mohanyang.presentation.screen.onboarding.guide.OnboardingGuideRoute
 import com.pomonyang.mohanyang.presentation.screen.onboarding.naming.OnboardingNamingCatRoute
 import com.pomonyang.mohanyang.presentation.screen.onboarding.select.OnboardingSelectCatRoute
-import com.pomonyang.mohanyang.presentation.screen.pomodoro.Home
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -97,7 +97,7 @@ fun NavGraphBuilder.onboardingScreen(
                     when (destination) {
                         CatSettingDestination.POMODORO -> {
                             navHostController.navigate(
-                                route = Home(isNewUser = true),
+                                route = Home,
                                 navOptions = NavOptions.Builder().setPopUpTo<OnboardingGuide>(true).build()
                             )
                         }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/OnboardingNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/OnboardingNavigator.kt
@@ -10,7 +10,7 @@ import com.pomonyang.mohanyang.presentation.model.cat.CatType
 import com.pomonyang.mohanyang.presentation.screen.onboarding.guide.OnboardingGuideRoute
 import com.pomonyang.mohanyang.presentation.screen.onboarding.naming.OnboardingNamingCatRoute
 import com.pomonyang.mohanyang.presentation.screen.onboarding.select.OnboardingSelectCatRoute
-import com.pomonyang.mohanyang.presentation.screen.pomodoro.Pomodoro
+import com.pomonyang.mohanyang.presentation.screen.pomodoro.Home
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -97,7 +97,7 @@ fun NavGraphBuilder.onboardingScreen(
                     when (destination) {
                         CatSettingDestination.POMODORO -> {
                             navHostController.navigate(
-                                route = Pomodoro(isNewUser = true),
+                                route = Home(isNewUser = true),
                                 navOptions = NavOptions.Builder().setPopUpTo<OnboardingGuide>(true).build()
                             )
                         }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroNavigator.kt
@@ -19,7 +19,7 @@ import com.pomonyang.mohanyang.presentation.screen.pomodoro.waiting.PomodoroRest
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class Pomodoro(
+data class Home(
     val isNewUser: Boolean
 )
 
@@ -48,7 +48,7 @@ fun NavGraphBuilder.pomodoroScreen(
     onShowSnackbar: (String, Int?) -> Unit,
     navHostController: NavHostController
 ) {
-    navigation<Pomodoro>(
+    navigation<Home>(
         startDestination = PomodoroSetting
     ) {
         val slideDuration = 500
@@ -97,7 +97,7 @@ fun NavGraphBuilder.pomodoroScreen(
 
         composable<PomodoroTimer> {
             PomodoroFocusRoute(
-                pomodoroTimerViewModel = hiltViewModel<PomodoroTimerViewModel>(navHostController.getBackStackEntry<Pomodoro>()),
+                pomodoroTimerViewModel = hiltViewModel<PomodoroTimerViewModel>(navHostController.getBackStackEntry<Home>()),
                 goToRest = { type, focusTime, exceededTime ->
                     navHostController.navigate(
                         PomodoroRestWaiting(
@@ -139,7 +139,7 @@ fun NavGraphBuilder.pomodoroScreen(
 
         composable<PomodoroRest> {
             PomodoroRestRoute(
-                pomodoroTimerViewModel = hiltViewModel<PomodoroTimerViewModel>(navHostController.getBackStackEntry<Pomodoro>()),
+                pomodoroTimerViewModel = hiltViewModel<PomodoroTimerViewModel>(navHostController.getBackStackEntry<Home>()),
                 onShowSnackbar = onShowSnackbar,
                 goToHome = {
                     navHostController.popBackStack()

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroNavigator.kt
@@ -77,8 +77,8 @@ fun NavGraphBuilder.pomodoroScreen(
                     }
                 },
                 forceGoHome = {
-                    navHostController.popBackStack()
                     onForceGoHome()
+                    navHostController.popBackStack()
                 },
                 onShowSnackbar = onShowSnackbar
             )

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroNavigator.kt
@@ -4,16 +4,18 @@ import androidx.compose.animation.EnterTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
 import androidx.navigation.toRoute
 import com.pomonyang.mohanyang.presentation.screen.mypage.MyPage
+import com.pomonyang.mohanyang.presentation.screen.pomodoro.focus.PomodoroFocusRoute
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.rest.PomodoroRestRoute
-import com.pomonyang.mohanyang.presentation.screen.pomodoro.rest.PomodoroRestWaitingRoute
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.setting.PomodoroSettingRoute
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.time.PomodoroTimeSettingRoute
+import com.pomonyang.mohanyang.presentation.screen.pomodoro.waiting.PomodoroRestWaitingRoute
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -94,7 +96,8 @@ fun NavGraphBuilder.pomodoroScreen(
         }
 
         composable<PomodoroTimer> {
-            PomodoroTimerRoute(
+            PomodoroFocusRoute(
+                pomodoroTimerViewModel = hiltViewModel<PomodoroTimerViewModel>(navHostController.getBackStackEntry<Pomodoro>()),
                 goToRest = { type, focusTime, exceededTime ->
                     navHostController.navigate(
                         PomodoroRestWaiting(
@@ -136,6 +139,7 @@ fun NavGraphBuilder.pomodoroScreen(
 
         composable<PomodoroRest> {
             PomodoroRestRoute(
+                pomodoroTimerViewModel = hiltViewModel<PomodoroTimerViewModel>(navHostController.getBackStackEntry<Pomodoro>()),
                 onShowSnackbar = onShowSnackbar,
                 goToHome = {
                     navHostController.popBackStack()

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
@@ -51,13 +51,10 @@ sealed interface PomodoroTimerEvent : ViewEvent {
 
 sealed interface PomodoroTimerEffect : ViewSideEffect {
     sealed interface PomodoroFocusEffect : PomodoroTimerEffect {
-        data object SendEndFocusAlarm : PomodoroFocusEffect
         data object ForceGoRest : PomodoroFocusEffect
     }
 
-    sealed interface PomodoroRestEffect : PomodoroTimerEffect {
-        data object SendEndRestAlarm : PomodoroRestEffect
-    }
+    sealed interface PomodoroRestEffect : PomodoroTimerEffect
 }
 
 @HiltViewModel
@@ -129,14 +126,6 @@ class PomodoroTimerViewModel @Inject constructor(
         val currentRestTime = timerData.restedTime.coerceAtMost(state.value.maxRestTime)
         val focusExceededTime = (timerData.focusedTime - state.value.maxFocusTime).coerceAtLeast(0)
         val restExceededTime = (timerData.restedTime - state.value.maxRestTime).coerceAtLeast(0)
-
-        if (timerData.focusedTime == state.value.maxFocusTime) {
-            setEffect(PomodoroTimerEffect.PomodoroFocusEffect.SendEndFocusAlarm)
-        }
-
-        if (timerData.restedTime == state.value.maxRestTime) {
-            setEffect(PomodoroTimerEffect.PomodoroRestEffect.SendEndRestAlarm)
-        }
 
         updateState {
             copy(

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.pomonyang.mohanyang.data.repository.pomodoro.PomodoroTimerRepository
 import com.pomonyang.mohanyang.data.repository.user.UserRepository
 import com.pomonyang.mohanyang.domain.usecase.GetSelectedPomodoroSettingUseCase
+import com.pomonyang.mohanyang.domain.usecase.InsertPomodoroInitialDataUseCase
 import com.pomonyang.mohanyang.presentation.base.BaseViewModel
 import com.pomonyang.mohanyang.presentation.base.ViewEvent
 import com.pomonyang.mohanyang.presentation.base.ViewSideEffect
@@ -12,135 +13,115 @@ import com.pomonyang.mohanyang.presentation.model.cat.CatType
 import com.pomonyang.mohanyang.presentation.model.cat.toModel
 import com.pomonyang.mohanyang.presentation.model.setting.PomodoroCategoryType
 import com.pomonyang.mohanyang.presentation.model.setting.toModel
-import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.MAX_EXCEEDED_TIME
-import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.ONE_SECOND
-import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.TIMER_DELAY
+import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants
 import com.pomonyang.mohanyang.presentation.util.formatTime
 import dagger.hilt.android.lifecycle.HiltViewModel
+import java.util.*
 import javax.inject.Inject
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import timber.log.Timber
 
 data class PomodoroTimerState(
-    val maxFocusTime: Int = 0,
-    val currentFocusTime: Int = 0,
-    val exceededTime: Int = 0,
+    val focusTime: Int = 0,
+    val focusExceededTime: Int = 0,
+    val restTime: Int = 0,
+    val restExceededTime: Int = 0,
     val title: String = "",
     val categoryType: PomodoroCategoryType = PomodoroCategoryType.DEFAULT,
     val cat: CatType = CatType.CHEESE,
     val categoryNo: Int = -1
 ) : ViewState {
-    fun displayFocusTime(): String = currentFocusTime.formatTime()
-    fun displayExceedTime(): String = exceededTime.formatTime()
+    fun displayFocusTime(): String = focusTime.formatTime()
+    fun displayRestTime(): String = restTime.formatTime()
+    fun displayFocusExceedTime(): String = focusExceededTime.formatTime()
+    fun displayRestExceedTime(): String = restExceededTime.formatTime()
 }
 
 sealed interface PomodoroTimerEvent : ViewEvent {
-    data object Init : PomodoroTimerEvent
-    data object ClickRest : PomodoroTimerEvent
-    data object ClickHome : PomodoroTimerEvent
-    data object Resume : PomodoroTimerEvent
-    data object Pause : PomodoroTimerEvent
-    data object Dispose : PomodoroTimerEvent
+    sealed interface PomodoroFocusEvent : PomodoroTimerEvent
+
+    sealed interface PomodoroRestEvent : PomodoroTimerEvent
 }
 
 sealed interface PomodoroTimerEffect : ViewSideEffect {
-    data class GoToPomodoroRest(
-        val title: String,
-        val focusTime: Int,
-        val exceededTime: Int
-    ) : PomodoroTimerEffect
+    sealed interface PomodoroFocusEffect : PomodoroTimerEffect
 
-    data object GoToPomodoroSetting : PomodoroTimerEffect
-    data object StartFocusAlarm : PomodoroTimerEffect
-    data object StopFocusAlarm : PomodoroTimerEffect
-    data object SendEndFocusAlarm : PomodoroTimerEffect
+    sealed interface PomodoroRestEffect : PomodoroTimerEffect
 }
 
 @HiltViewModel
 class PomodoroTimerViewModel @Inject constructor(
     private val getSelectedPomodoroSettingUseCase: GetSelectedPomodoroSettingUseCase,
     private val pomodoroTimerRepository: PomodoroTimerRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val pomodoroInitialDataUseCase: InsertPomodoroInitialDataUseCase
 ) : BaseViewModel<PomodoroTimerState, PomodoroTimerEvent, PomodoroTimerEffect>() {
 
-    private var timerJob: Job? = null
+    private var maxFocusTime: Int = 0
+    private var maxRestTime: Int = 0
+    private var currentFocusTimerId = UUID.randomUUID().toString()
+
+    init {
+        viewModelScope.launch {
+            pomodoroInitialDataUseCase(currentFocusTimerId)
+        }.invokeOnCompletion {
+            loadPomodoroSettingData()
+            collectTimer()
+        }
+    }
+
+    private fun loadPomodoroSettingData() {
+        viewModelScope.launch {
+            val selectedPomodoroSetting = getSelectedPomodoroSettingUseCase().first().toModel()
+            val cat = userRepository.getMyInfo().cat.toModel()
+            maxFocusTime = (selectedPomodoroSetting.focusTime.times(60))
+            updateState {
+                copy(
+                    title = selectedPomodoroSetting.title,
+                    categoryType = selectedPomodoroSetting.categoryType,
+                    cat = cat.type
+                )
+            }
+        }
+    }
 
     override fun setInitialState(): PomodoroTimerState = PomodoroTimerState()
 
     override fun handleEvent(event: PomodoroTimerEvent) {
-        when (event) {
-            PomodoroTimerEvent.Init -> viewModelScope.launch {
-                val selectedPomodoroSetting = getSelectedPomodoroSettingUseCase().first().toModel()
-                val cat = userRepository.getMyInfo().cat.toModel()
-                updateState {
-                    copy(
-                        title = selectedPomodoroSetting.title,
-                        categoryType = selectedPomodoroSetting.categoryType,
-                        maxFocusTime = (selectedPomodoroSetting.focusTime.times(60)),
-                        categoryNo = selectedPomodoroSetting.categoryNo,
-                        cat = cat.type
-                    )
-                }
-                pomodoroTimerRepository.insertPomodoroTimerInitData(selectedPomodoroSetting.categoryNo)
-                startTimer()
-            }
-
-            PomodoroTimerEvent.ClickRest -> setEffect(
-                PomodoroTimerEffect.GoToPomodoroRest(
-                    title = state.value.title,
-                    focusTime = state.value.currentFocusTime,
-                    exceededTime = state.value.exceededTime
-                )
-            )
-
-            PomodoroTimerEvent.ClickHome -> {
-                viewModelScope.launch {
-                    pomodoroTimerRepository.updatePomodoroDone()
-                    pomodoroTimerRepository.savePomodoroCacheData()
-                }
-                setEffect(PomodoroTimerEffect.GoToPomodoroSetting)
-            }
-
-            PomodoroTimerEvent.Pause -> setEffect(PomodoroTimerEffect.StartFocusAlarm)
-            PomodoroTimerEvent.Resume -> setEffect(PomodoroTimerEffect.StopFocusAlarm)
-            PomodoroTimerEvent.Dispose -> setEffect(PomodoroTimerEffect.StopFocusAlarm)
-        }
+        // TODO [코니]
     }
 
-    private fun startTimer() {
-        timerJob?.cancel()
-        timerJob = CoroutineScope(Dispatchers.IO).launch {
-            while (isActive) {
-                delay(TIMER_DELAY)
+    private fun collectTimer() {
+        viewModelScope.launch {
+            pomodoroTimerRepository.getPomodoroTimer(currentFocusTimerId).collect { timerData ->
+                timerData ?: return@collect
+                Timber.tag("koni").d("timerData $timerData")
+                val currentFocusTime = timerData.focusedTime.coerceAtMost(maxFocusTime)
+                val currentRestTime = timerData.restedTime.coerceAtMost(maxRestTime)
+                val focusExceededTime = (timerData.focusedTime - maxFocusTime).coerceAtLeast(0)
+                val restExceededTime = (timerData.focusedTime - maxRestTime).coerceAtLeast(0)
+                if (timerData.focusedTime == maxFocusTime) {
+                    Timber.tag("koni").d("timerData.focusedTime == maxFocusTime")
+                    // TODO [코니] 포커스 알림 보내야 함
+                }
+
+                if (timerData.restedTime == maxRestTime) {
+                    Timber.tag("koni").d("timerData.restedTime == maxRestTime")
+                    // TODO [코니] 휴식 알림 보내야 함
+                }
                 updateState {
-                    if (currentFocusTime < maxFocusTime) {
-                        val newFocusTime = currentFocusTime + ONE_SECOND
-                        viewModelScope.launch {
-                            pomodoroTimerRepository.updateFocusTime(newFocusTime)
-                        }
-                        copy(currentFocusTime = currentFocusTime + ONE_SECOND)
-                    } else {
-                        if (exceededTime == 0) {
-                            setEffect(PomodoroTimerEffect.SendEndFocusAlarm)
-                        }
-                        val newExceedTime = exceededTime + ONE_SECOND
-                        if (newExceedTime >= MAX_EXCEEDED_TIME) {
-                            timerJob?.cancel()
-                            setEffect(
-                                PomodoroTimerEffect.GoToPomodoroRest(
-                                    title = state.value.title,
-                                    focusTime = state.value.currentFocusTime,
-                                    exceededTime = newExceedTime
-                                )
-                            )
-                        }
-                        copy(exceededTime = newExceedTime)
-                    }
+                    copy(
+                        focusTime = currentFocusTime,
+                        focusExceededTime = focusExceededTime,
+                        restTime = currentRestTime,
+                        restExceededTime = restExceededTime
+                    )
+                }
+
+                if (focusExceededTime == PomodoroConstants.MAX_EXCEEDED_TIME) {
+                    Timber.tag("koni").d("focusExceededTime == PomodoroConstants.MAX_EXCEEDED_TIME")
+                    // TODO [코니] 여기 최대 초과시간 지났으면 홈으로 강제 이동
                 }
             }
         }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
@@ -17,7 +17,7 @@ import com.pomonyang.mohanyang.presentation.model.setting.toModel
 import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants
 import com.pomonyang.mohanyang.presentation.util.formatTime
 import dagger.hilt.android.lifecycle.HiltViewModel
-import java.util.*
+import java.util.UUID
 import javax.inject.Inject
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
@@ -138,7 +138,6 @@ class PomodoroTimerViewModel @Inject constructor(
     @OptIn(DelicateCoroutinesApi::class)
     private fun savePomodoroData() {
         GlobalScope.launch {
-            pomodoroTimerRepository.updatePomodoroDone(currentFocusTimerId.value)
             pomodoroTimerRepository.savePomodoroData(currentFocusTimerId.value)
         }
     }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
@@ -19,6 +19,8 @@ import com.pomonyang.mohanyang.presentation.util.formatTime
 import dagger.hilt.android.lifecycle.HiltViewModel
 import java.util.*
 import javax.inject.Inject
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.launch
@@ -135,10 +137,16 @@ class PomodoroTimerViewModel @Inject constructor(
         }
     }
 
+    @OptIn(DelicateCoroutinesApi::class)
     private fun savePomodoroData() {
-        viewModelScope.launch {
+        GlobalScope.launch {
             pomodoroTimerRepository.updatePomodoroDone(currentFocusTimerId.value)
             pomodoroTimerRepository.savePomodoroData(currentFocusTimerId.value)
         }
+    }
+
+    override fun onCleared() {
+        savePomodoroData()
+        super.onCleared()
     }
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
@@ -42,8 +42,6 @@ data class PomodoroTimerState(
 }
 
 sealed interface PomodoroTimerEvent : ViewEvent {
-    data object Start : PomodoroTimerEvent
-
     // 포커스, 휴식 이벤트 분리를 했는데 나중에 필요하면 상속받고 추가
     sealed interface PomodoroFocusEvent : PomodoroTimerEvent
     sealed interface PomodoroRestEvent : PomodoroTimerEvent
@@ -72,6 +70,8 @@ class PomodoroTimerViewModel @Inject constructor(
     }
 
     init {
+        loadPomodoroSettingData()
+        initPomodoroData()
         loadTimerData()
     }
 
@@ -86,13 +86,6 @@ class PomodoroTimerViewModel @Inject constructor(
     override fun setInitialState(): PomodoroTimerState = PomodoroTimerState()
 
     override fun handleEvent(event: PomodoroTimerEvent) {
-        when (event) {
-            PomodoroTimerEvent.Start -> {
-                setInitialState()
-                loadPomodoroSettingData()
-                initPomodoroData()
-            }
-        }
     }
 
     private fun loadPomodoroSettingData() {
@@ -144,8 +137,8 @@ class PomodoroTimerViewModel @Inject constructor(
 
     private fun savePomodoroData() {
         viewModelScope.launch {
-            pomodoroTimerRepository.updatePomodoroDone()
-            pomodoroTimerRepository.savePomodoroCacheData()
+            pomodoroTimerRepository.updatePomodoroDone(currentFocusTimerId.value)
+            pomodoroTimerRepository.savePomodoroData(currentFocusTimerId.value)
         }
     }
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
@@ -130,7 +130,6 @@ class PomodoroTimerViewModel @Inject constructor(
         }
 
         if (focusExceededTime == PomodoroConstants.MAX_EXCEEDED_TIME) {
-            savePomodoroData()
             updateState { copy(forceGoRest = true) }
         }
     }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
@@ -137,7 +137,15 @@ class PomodoroTimerViewModel @Inject constructor(
         }
 
         if (focusExceededTime == PomodoroConstants.MAX_EXCEEDED_TIME) {
+            savePomodoroData()
             setEffect(PomodoroTimerEffect.PomodoroFocusEffect.ForceGoRest)
+        }
+    }
+
+    private fun savePomodoroData() {
+        viewModelScope.launch {
+            pomodoroTimerRepository.updatePomodoroDone()
+            pomodoroTimerRepository.savePomodoroCacheData()
         }
     }
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/PomodoroTimerViewModel.kt
@@ -35,7 +35,8 @@ data class PomodoroTimerState(
     val title: String = "",
     val categoryType: PomodoroCategoryType = PomodoroCategoryType.DEFAULT,
     val cat: CatType = CatType.CHEESE,
-    val categoryNo: Int = -1
+    val categoryNo: Int = -1,
+    val forceGoRest: Boolean = false
 ) : ViewState {
     fun displayFocusTime(): String = focusTime.formatTime()
     fun displayRestTime(): String = restTime.formatTime()
@@ -50,10 +51,7 @@ sealed interface PomodoroTimerEvent : ViewEvent {
 }
 
 sealed interface PomodoroTimerEffect : ViewSideEffect {
-    sealed interface PomodoroFocusEffect : PomodoroTimerEffect {
-        data object ForceGoRest : PomodoroFocusEffect
-    }
-
+    sealed interface PomodoroFocusEffect : PomodoroTimerEffect
     sealed interface PomodoroRestEffect : PomodoroTimerEffect
 }
 
@@ -133,7 +131,7 @@ class PomodoroTimerViewModel @Inject constructor(
 
         if (focusExceededTime == PomodoroConstants.MAX_EXCEEDED_TIME) {
             savePomodoroData()
-            setEffect(PomodoroTimerEffect.PomodoroFocusEffect.ForceGoRest)
+            updateState { copy(forceGoRest = true) }
         }
     }
 

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusScreen.kt
@@ -1,5 +1,6 @@
 package com.pomonyang.mohanyang.presentation.screen.pomodoro.focus
 
+import android.content.Context
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
@@ -10,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -65,6 +65,7 @@ fun PomodoroFocusRoute(
     pomodoroFocusViewModel.effects.collectWithLifecycle(minActiveState = Lifecycle.State.CREATED) { effect ->
         when (effect) {
             is PomodoroFocusEffect.GoToPomodoroRest -> {
+                stopNotification(context)
                 goToRest(
                     context.getString(state.categoryType.kor),
                     state.focusTime,
@@ -73,6 +74,7 @@ fun PomodoroFocusRoute(
             }
 
             PomodoroFocusEffect.GoToPomodoroSetting -> {
+                stopNotification(context)
                 goToHome()
             }
 
@@ -110,13 +112,6 @@ fun PomodoroFocusRoute(
         }
     }
 
-    DisposableEffect(key1 = Unit) {
-        onDispose {
-            stopInterrupt(context)
-            context.stopTimer(true)
-        }
-    }
-
     PomodoroTimerScreen(
         modifier = modifier,
         title = state.title,
@@ -126,6 +121,11 @@ fun PomodoroFocusRoute(
         exceededTime = state.displayFocusExceedTime(),
         onAction = remember { pomodoroFocusViewModel::handleEvent }
     )
+}
+
+private fun stopNotification(context: Context) {
+    stopInterrupt(context)
+    context.stopTimer(true)
 }
 
 @Composable

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusScreen.kt
@@ -62,7 +62,7 @@ fun PomodoroFocusRoute(
         // NOTHING
     }
 
-    pomodoroFocusViewModel.effects.collectWithLifecycle(minActiveState = Lifecycle.State.CREATED) { effect ->
+    pomodoroFocusViewModel.effects.collectWithLifecycle { effect ->
         when (effect) {
             is PomodoroFocusEffect.GoToPomodoroRest -> {
                 stopNotification(context)

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusScreen.kt
@@ -43,7 +43,6 @@ import com.pomonyang.mohanyang.presentation.screen.pomodoro.PomodoroTimerEvent
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.PomodoroTimerViewModel
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.DevicePreviews
-import com.pomonyang.mohanyang.presentation.util.MnNotificationManager.notifyFocusEnd
 import com.pomonyang.mohanyang.presentation.util.MnNotificationManager.startInterrupt
 import com.pomonyang.mohanyang.presentation.util.MnNotificationManager.stopInterrupt
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
@@ -99,8 +98,6 @@ fun PomodoroFocusRoute(
                         state.focusExceededTime
                     )
                 }
-
-                PomodoroTimerEffect.PomodoroFocusEffect.SendEndFocusAlarm -> notifyFocusEnd(context)
             }
         }
     }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -112,9 +113,14 @@ fun PomodoroFocusRoute(
         pomodoroFocusViewModel.handleEvent(PomodoroFocusEvent.Pause)
     }
 
+    LaunchedEffect(state.maxFocusTime) {
+        if (state.maxFocusTime != 0) {
+            context.startTimer(true, state.maxFocusTime)
+        }
+    }
+
     DisposableEffect(key1 = Unit) {
         pomodoroTimerViewModel.handleEvent(PomodoroTimerEvent.Start)
-        context.startTimer(true)
         onDispose {
             stopInterrupt(context)
             context.stopTimer(true)

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusScreen.kt
@@ -38,7 +38,6 @@ import com.pomonyang.mohanyang.presentation.designsystem.topappbar.MnTopAppBar
 import com.pomonyang.mohanyang.presentation.model.cat.CatType
 import com.pomonyang.mohanyang.presentation.model.setting.PomodoroCategoryType
 import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.DEFAULT_TIME
-import com.pomonyang.mohanyang.presentation.screen.pomodoro.PomodoroTimerEffect
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.PomodoroTimerViewModel
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.DevicePreviews
@@ -87,20 +86,6 @@ fun PomodoroFocusRoute(
         }
     }
 
-    pomodoroTimerViewModel.effects.collectWithLifecycle(minActiveState = Lifecycle.State.CREATED) { effect ->
-        if (effect is PomodoroTimerEffect.PomodoroFocusEffect) {
-            when (effect) {
-                PomodoroTimerEffect.PomodoroFocusEffect.ForceGoRest -> {
-                    goToRest(
-                        context.getString(state.categoryType.kor),
-                        state.focusTime,
-                        state.focusExceededTime
-                    )
-                }
-            }
-        }
-    }
-
     LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
         pomodoroFocusViewModel.handleEvent(PomodoroFocusEvent.Resume)
     }
@@ -112,6 +97,16 @@ fun PomodoroFocusRoute(
     LaunchedEffect(state.maxFocusTime) {
         if (state.maxFocusTime != 0) {
             context.startTimer(true, state.maxFocusTime)
+        }
+    }
+
+    LaunchedEffect(state.forceGoRest) {
+        if (state.forceGoRest) {
+            goToRest(
+                context.getString(state.categoryType.kor),
+                state.focusTime,
+                state.focusExceededTime
+            )
         }
     }
 

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusScreen.kt
@@ -39,7 +39,6 @@ import com.pomonyang.mohanyang.presentation.model.cat.CatType
 import com.pomonyang.mohanyang.presentation.model.setting.PomodoroCategoryType
 import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.DEFAULT_TIME
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.PomodoroTimerEffect
-import com.pomonyang.mohanyang.presentation.screen.pomodoro.PomodoroTimerEvent
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.PomodoroTimerViewModel
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.DevicePreviews
@@ -117,7 +116,6 @@ fun PomodoroFocusRoute(
     }
 
     DisposableEffect(key1 = Unit) {
-        pomodoroTimerViewModel.handleEvent(PomodoroTimerEvent.Start)
         onDispose {
             stopInterrupt(context)
             context.stopTimer(true)

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusScreen.kt
@@ -88,7 +88,7 @@ fun PomodoroFocusRoute(
         }
     }
 
-    pomodoroTimerViewModel.effects.collectWithLifecycle { effect ->
+    pomodoroTimerViewModel.effects.collectWithLifecycle(minActiveState = Lifecycle.State.CREATED) { effect ->
         if (effect is PomodoroTimerEffect.PomodoroFocusEffect) {
             when (effect) {
                 PomodoroTimerEffect.PomodoroFocusEffect.ForceGoRest -> {

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusViewModel.kt
@@ -1,14 +1,11 @@
 package com.pomonyang.mohanyang.presentation.screen.pomodoro.focus
 
-import androidx.lifecycle.viewModelScope
-import com.pomonyang.mohanyang.data.repository.pomodoro.PomodoroTimerRepository
 import com.pomonyang.mohanyang.presentation.base.BaseViewModel
 import com.pomonyang.mohanyang.presentation.base.ViewEvent
 import com.pomonyang.mohanyang.presentation.base.ViewSideEffect
 import com.pomonyang.mohanyang.presentation.base.ViewState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.launch
 
 data object PomodoroFocusState : ViewState
 
@@ -28,24 +25,14 @@ sealed interface PomodoroFocusEffect : ViewSideEffect {
 }
 
 @HiltViewModel
-class PomodoroFocusViewModel @Inject constructor(
-    private val pomodoroTimerRepository: PomodoroTimerRepository
-) : BaseViewModel<PomodoroFocusState, PomodoroFocusEvent, PomodoroFocusEffect>() {
+class PomodoroFocusViewModel @Inject constructor() : BaseViewModel<PomodoroFocusState, PomodoroFocusEvent, PomodoroFocusEffect>() {
 
     override fun setInitialState(): PomodoroFocusState = PomodoroFocusState
 
     override fun handleEvent(event: PomodoroFocusEvent) {
         when (event) {
             PomodoroFocusEvent.ClickRest -> setEffect(PomodoroFocusEffect.GoToPomodoroRest)
-
-            PomodoroFocusEvent.ClickHome -> {
-                viewModelScope.launch {
-                    pomodoroTimerRepository.updatePomodoroDone()
-                    pomodoroTimerRepository.savePomodoroCacheData()
-                }
-                setEffect(PomodoroFocusEffect.GoToPomodoroSetting)
-            }
-
+            PomodoroFocusEvent.ClickHome -> setEffect(PomodoroFocusEffect.GoToPomodoroSetting)
             PomodoroFocusEvent.Pause -> setEffect(PomodoroFocusEffect.StartFocusAlarm)
             PomodoroFocusEvent.Resume -> setEffect(PomodoroFocusEffect.StopFocusAlarm)
             PomodoroFocusEvent.Dispose -> setEffect(PomodoroFocusEffect.StopFocusAlarm)

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/focus/PomodoroFocusViewModel.kt
@@ -1,0 +1,54 @@
+package com.pomonyang.mohanyang.presentation.screen.pomodoro.focus
+
+import androidx.lifecycle.viewModelScope
+import com.pomonyang.mohanyang.data.repository.pomodoro.PomodoroTimerRepository
+import com.pomonyang.mohanyang.presentation.base.BaseViewModel
+import com.pomonyang.mohanyang.presentation.base.ViewEvent
+import com.pomonyang.mohanyang.presentation.base.ViewSideEffect
+import com.pomonyang.mohanyang.presentation.base.ViewState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import kotlinx.coroutines.launch
+
+data object PomodoroFocusState : ViewState
+
+sealed interface PomodoroFocusEvent : ViewEvent {
+    data object ClickRest : PomodoroFocusEvent
+    data object ClickHome : PomodoroFocusEvent
+    data object Resume : PomodoroFocusEvent
+    data object Pause : PomodoroFocusEvent
+    data object Dispose : PomodoroFocusEvent
+}
+
+sealed interface PomodoroFocusEffect : ViewSideEffect {
+    data object GoToPomodoroRest : PomodoroFocusEffect
+    data object GoToPomodoroSetting : PomodoroFocusEffect
+    data object StartFocusAlarm : PomodoroFocusEffect
+    data object StopFocusAlarm : PomodoroFocusEffect
+}
+
+@HiltViewModel
+class PomodoroFocusViewModel @Inject constructor(
+    private val pomodoroTimerRepository: PomodoroTimerRepository
+) : BaseViewModel<PomodoroFocusState, PomodoroFocusEvent, PomodoroFocusEffect>() {
+
+    override fun setInitialState(): PomodoroFocusState = PomodoroFocusState
+
+    override fun handleEvent(event: PomodoroFocusEvent) {
+        when (event) {
+            PomodoroFocusEvent.ClickRest -> setEffect(PomodoroFocusEffect.GoToPomodoroRest)
+
+            PomodoroFocusEvent.ClickHome -> {
+                viewModelScope.launch {
+                    pomodoroTimerRepository.updatePomodoroDone()
+                    pomodoroTimerRepository.savePomodoroCacheData()
+                }
+                setEffect(PomodoroFocusEffect.GoToPomodoroSetting)
+            }
+
+            PomodoroFocusEvent.Pause -> setEffect(PomodoroFocusEffect.StartFocusAlarm)
+            PomodoroFocusEvent.Resume -> setEffect(PomodoroFocusEffect.StopFocusAlarm)
+            PomodoroFocusEvent.Dispose -> setEffect(PomodoroFocusEffect.StopFocusAlarm)
+        }
+    }
+}

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -61,10 +60,12 @@ fun PomodoroRestRoute(
         when (effect) {
             is PomodoroRestEffect.ShowSnackbar -> onShowSnackbar(effect.message, effect.iconRes)
             PomodoroRestEffect.GoToHome -> {
+                context.stopTimer(false)
                 goToHome()
             }
 
             PomodoroRestEffect.GoToPomodoroFocus -> {
+                context.stopTimer(false)
                 goToFocus()
             }
         }
@@ -77,12 +78,6 @@ fun PomodoroRestRoute(
     LaunchedEffect(timerState.maxRestTime) {
         if (timerState.maxRestTime != 0) {
             context.startTimer(false, timerState.maxRestTime)
-        }
-    }
-
-    DisposableEffect(Unit) {
-        onDispose {
-            context.stopTimer(false)
         }
     }
 

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestScreen.kt
@@ -41,7 +41,6 @@ import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.DEFAULT_TIM
 import com.pomonyang.mohanyang.presentation.screen.pomodoro.PomodoroTimerViewModel
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.DevicePreviews
-import com.pomonyang.mohanyang.presentation.util.MnNotificationManager.notifyRestEnd
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
 import com.pomonyang.mohanyang.presentation.util.startTimer
 import com.pomonyang.mohanyang.presentation.util.stopTimer
@@ -68,8 +67,6 @@ fun PomodoroRestRoute(
             PomodoroRestEffect.GoToPomodoroFocus -> {
                 goToFocus()
             }
-
-            PomodoroRestEffect.SendEndRestAlarm -> notifyRestEnd(context)
         }
     }
 

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.mohanyang.presentation.R
 import com.pomonyang.mohanyang.presentation.component.CatRive
@@ -56,7 +55,7 @@ fun PomodoroRestRoute(
     val timerState by pomodoroTimerViewModel.state.collectAsStateWithLifecycle()
     val restState by pomodoroRestViewModel.state.collectAsStateWithLifecycle()
     val context = LocalContext.current
-    pomodoroRestViewModel.effects.collectWithLifecycle(minActiveState = Lifecycle.State.CREATED) { effect ->
+    pomodoroRestViewModel.effects.collectWithLifecycle { effect ->
         when (effect) {
             is PomodoroRestEffect.ShowSnackbar -> onShowSnackbar(effect.message, effect.iconRes)
             PomodoroRestEffect.GoToHome -> {

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestScreen.kt
@@ -79,8 +79,6 @@ fun PomodoroRestRoute(
     DisposableEffect(Unit) {
         context.startTimer(false)
 
-        pomodoroRestViewModel.handleEvent(PomodoroRestEvent.Init)
-
         onDispose {
             context.stopTimer(false)
         }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -76,9 +77,13 @@ fun PomodoroRestRoute(
         // NOTHING
     }
 
-    DisposableEffect(Unit) {
-        context.startTimer(false)
+    LaunchedEffect(timerState.maxRestTime) {
+        if (timerState.maxRestTime != 0) {
+            context.startTimer(false, timerState.maxRestTime)
+        }
+    }
 
+    DisposableEffect(Unit) {
         onDispose {
             context.stopTimer(false)
         }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestViewModel.kt
@@ -88,23 +88,14 @@ class PomodoroRestViewModel @Inject constructor(
             }
 
             PomodoroRestEvent.OnEndPomodoroClick -> {
-                savePomodoroData()
                 adjustRestTime()
                 setEffect(PomodoroRestEffect.GoToHome)
             }
 
             PomodoroRestEvent.OnFocusClick -> {
-                savePomodoroData()
                 adjustRestTime()
                 setEffect(PomodoroRestEffect.GoToPomodoroFocus)
             }
-        }
-    }
-
-    private fun savePomodoroData() {
-        viewModelScope.launch {
-            pomodoroTimerRepository.updatePomodoroDone()
-            pomodoroTimerRepository.savePomodoroCacheData()
         }
     }
 

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/rest/PomodoroRestViewModel.kt
@@ -36,7 +36,6 @@ sealed interface PomodoroRestEffect : ViewSideEffect {
     data class ShowSnackbar(val message: String, @DrawableRes val iconRes: Int) : PomodoroRestEffect
     data object GoToHome : PomodoroRestEffect
     data object GoToPomodoroFocus : PomodoroRestEffect
-    data object SendEndRestAlarm : PomodoroRestEffect
 }
 
 @HiltViewModel

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/waiting/PomodoroRestWaitingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/waiting/PomodoroRestWaitingScreen.kt
@@ -57,7 +57,6 @@ fun PomodoroRestWaitingRoute(
             PomodoroRestWaitingSideEffect.GoToPomodoroSetting -> goToHome()
             is PomodoroRestWaitingSideEffect.ShowSnackbar -> onShowSnackbar(effect.message, effect.iconRes)
             PomodoroRestWaitingSideEffect.GoToPomodoroRest -> goToPomodoroRest()
-            PomodoroRestWaitingSideEffect.ForceGoPomodoroSetting -> forceGoHome()
         }
     }
 
@@ -73,6 +72,12 @@ fun PomodoroRestWaitingRoute(
                 focusTime = focusTime
             )
         )
+    }
+
+    LaunchedEffect(state.forceGoHome) {
+        if (state.forceGoHome) {
+            forceGoHome()
+        }
     }
 
     PomodoroRestWaitingScreen(

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/waiting/PomodoroRestWaitingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/waiting/PomodoroRestWaitingScreen.kt
@@ -1,4 +1,4 @@
-package com.pomonyang.mohanyang.presentation.screen.pomodoro.rest
+package com.pomonyang.mohanyang.presentation.screen.pomodoro.waiting
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/waiting/PomodoroRestWaitingViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/waiting/PomodoroRestWaitingViewModel.kt
@@ -1,4 +1,4 @@
-package com.pomonyang.mohanyang.presentation.screen.pomodoro.rest
+package com.pomonyang.mohanyang.presentation.screen.pomodoro.waiting
 
 import androidx.annotation.DrawableRes
 import androidx.lifecycle.viewModelScope

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/waiting/PomodoroRestWaitingViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/waiting/PomodoroRestWaitingViewModel.kt
@@ -4,7 +4,6 @@ import androidx.annotation.DrawableRes
 import androidx.lifecycle.viewModelScope
 import com.mohanyang.presentation.BuildConfig
 import com.mohanyang.presentation.R
-import com.pomonyang.mohanyang.data.repository.pomodoro.PomodoroTimerRepository
 import com.pomonyang.mohanyang.domain.usecase.AdjustPomodoroTimeUseCase
 import com.pomonyang.mohanyang.domain.usecase.GetSelectedPomodoroSettingUseCase
 import com.pomonyang.mohanyang.presentation.base.BaseViewModel
@@ -27,7 +26,8 @@ data class PomodoroRestWaitingState(
     val plusButtonSelected: Boolean = false,
     val minusButtonSelected: Boolean = false,
     val plusButtonEnabled: Boolean = true,
-    val minusButtonEnabled: Boolean = true
+    val minusButtonEnabled: Boolean = true,
+    val forceGoHome: Boolean = false
 ) : ViewState
 
 sealed interface PomodoroRestWaitingEvent : ViewEvent {
@@ -47,7 +47,6 @@ sealed interface PomodoroRestWaitingEvent : ViewEvent {
 sealed interface PomodoroRestWaitingSideEffect : ViewSideEffect {
     data object GoToPomodoroSetting : PomodoroRestWaitingSideEffect
     data object GoToPomodoroRest : PomodoroRestWaitingSideEffect
-    data object ForceGoPomodoroSetting : PomodoroRestWaitingSideEffect
 
     data class ShowSnackbar(
         val message: String,
@@ -58,8 +57,7 @@ sealed interface PomodoroRestWaitingSideEffect : ViewSideEffect {
 @HiltViewModel
 class PomodoroRestWaitingViewModel @Inject constructor(
     private val getSelectedPomodoroSettingUseCase: GetSelectedPomodoroSettingUseCase,
-    private val adjustPomodoroTimeUseCase: AdjustPomodoroTimeUseCase,
-    private val pomodoroTimerRepository: PomodoroTimerRepository
+    private val adjustPomodoroTimeUseCase: AdjustPomodoroTimeUseCase
 ) : BaseViewModel<PomodoroRestWaitingState, PomodoroRestWaitingEvent, PomodoroRestWaitingSideEffect>() {
 
     override fun setInitialState(): PomodoroRestWaitingState = PomodoroRestWaitingState()
@@ -132,7 +130,7 @@ class PomodoroRestWaitingViewModel @Inject constructor(
                 }
                 count += 1
                 if (count == if (BuildConfig.DEBUG) 10 else 60) {
-                    setEffect(PomodoroRestWaitingSideEffect.ForceGoPomodoroSetting)
+                    updateState { copy(forceGoHome = true) }
                 }
             }
         }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/waiting/PomodoroRestWaitingViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/pomodoro/waiting/PomodoroRestWaitingViewModel.kt
@@ -111,10 +111,6 @@ class PomodoroRestWaitingViewModel @Inject constructor(
 
             PomodoroRestWaitingEvent.OnEndFocusClick -> {
                 adjustFocusTime()
-                viewModelScope.launch {
-                    pomodoroTimerRepository.updatePomodoroDone()
-                    pomodoroTimerRepository.savePomodoroCacheData()
-                }
                 setEffect(PomodoroRestWaitingSideEffect.GoToPomodoroSetting)
             }
 

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerService.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerService.kt
@@ -1,16 +1,24 @@
 package com.pomonyang.mohanyang.presentation.util
 
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.app.Service
 import android.content.Intent
 import android.os.IBinder
+import androidx.core.app.NotificationCompat
 import com.pomonyang.mohanyang.data.repository.pomodoro.PomodoroTimerRepository
+import com.pomonyang.mohanyang.presentation.di.PomodoroNotification
 import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.MAX_EXCEEDED_TIME
 import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.ONE_SECOND
+import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.POMODORO_NOTIFICATION_CHANNEL_ID
+import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.POMODORO_NOTIFICATION_CHANNEL_NAME
+import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.POMODORO_NOTIFICATION_ID
 import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.TIMER_DELAY
 import com.pomonyang.mohanyang.presentation.util.MnNotificationManager.notifyFocusEnd
 import com.pomonyang.mohanyang.presentation.util.MnNotificationManager.notifyRestEnd
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.*
+import java.util.Timer
 import javax.inject.Inject
 import kotlin.concurrent.fixedRateTimer
 import kotlinx.coroutines.CoroutineScope
@@ -23,6 +31,13 @@ class PomodoroTimerService : Service() {
 
     @Inject
     lateinit var pomodoroTimerRepository: PomodoroTimerRepository
+
+    @PomodoroNotification
+    @Inject
+    lateinit var notificationBuilder: NotificationCompat.Builder
+
+    @Inject
+    lateinit var notificationManager: NotificationManager
 
     private var focusTimer: Timer? = null
     private var restTimer: Timer? = null
@@ -40,6 +55,7 @@ class PomodoroTimerService : Service() {
 
         when (action) {
             PomodoroTimerServiceExtras.ACTION_TIMER_START -> {
+                startForeground(POMODORO_NOTIFICATION_ID, createNotification(isFocus))
                 if (isFocus) {
                     startFocusTimer(maxTime)
                 } else {
@@ -48,6 +64,7 @@ class PomodoroTimerService : Service() {
             }
 
             PomodoroTimerServiceExtras.ACTION_TIMER_STOP -> {
+                stopForeground(STOP_FOREGROUND_REMOVE)
                 if (isFocus) {
                     stopFocusTimer()
                 } else {
@@ -56,11 +73,12 @@ class PomodoroTimerService : Service() {
             }
         }
 
-        return START_STICKY
+        return START_NOT_STICKY
     }
 
     override fun stopService(name: Intent?): Boolean {
         Timber.tag(TAG).d("stopService")
+        stopForeground(STOP_FOREGROUND_REMOVE)
         stopFocusTimer()
         stopRestTimer()
         return super.stopService(name)
@@ -69,6 +87,7 @@ class PomodoroTimerService : Service() {
     private fun startFocusTimer(maxTime: Int) {
         if (focusTimer == null) {
             var focusTimeElapsed = 0
+            Timber.tag(TAG).d("Focus 타이머 시작 ${this@PomodoroTimerService.hashCode()}")
             focusTimer = fixedRateTimer(initialDelay = TIMER_DELAY, period = TIMER_DELAY) {
                 scope.launch {
                     focusTimeElapsed += ONE_SECOND
@@ -80,9 +99,15 @@ class PomodoroTimerService : Service() {
 
                     if (focusTimeElapsed > maxTime + MAX_EXCEEDED_TIME) {
                         Timber.tag(TAG).d("Focus 타이머가 최대 머무를 수 있는 ${maxTime + MAX_EXCEEDED_TIME} 에 도달하여 중지됨")
+                        notificationManager.notify(
+                            POMODORO_NOTIFICATION_ID,
+                            notificationBuilder.setContentText(
+                                "너무 오랫동안 자리를 비웠다냥"
+                            ).build()
+                        )
                         stopFocusTimer()
                     } else {
-                        Timber.tag(TAG).d("Focus 타이머 작동 중 / 경과 시간: $focusTimeElapsed")
+                        Timber.tag(TAG).d("Focus 타이머 작동 중 / 경과 시간: $focusTimeElapsed ${this@PomodoroTimerService.hashCode()}")
                         pomodoroTimerRepository.incrementFocusedTime()
                     }
                 }
@@ -90,15 +115,10 @@ class PomodoroTimerService : Service() {
         }
     }
 
-    private fun stopFocusTimer() {
-        focusTimer?.cancel()
-        focusTimer = null
-        Timber.tag(TAG).d("Focus 타이머 중지")
-    }
-
     private fun startRestTimer(maxTime: Int) {
         if (restTimer == null) {
             var restTimeElapsed = 0
+            Timber.tag(TAG).d("Rest 타이머 시작 ${this@PomodoroTimerService.hashCode()}")
             restTimer = fixedRateTimer(initialDelay = TIMER_DELAY, period = TIMER_DELAY) {
                 scope.launch {
                     restTimeElapsed += ONE_SECOND
@@ -112,7 +132,7 @@ class PomodoroTimerService : Service() {
                         Timber.tag(TAG).d("Rest 타이머가 최대 머무를 수 있는 ${maxTime + MAX_EXCEEDED_TIME} 에 도달하여 중지됨")
                         stopRestTimer()
                     } else {
-                        Timber.tag(TAG).d("Rest 타이머 작동 중 / 경과 시간: $restTimeElapsed")
+                        Timber.tag(TAG).d("Rest 타이머 작동 중 / 경과 시간: $restTimeElapsed ${this@PomodoroTimerService.hashCode()}")
                         pomodoroTimerRepository.incrementRestedTime()
                     }
                 }
@@ -120,10 +140,35 @@ class PomodoroTimerService : Service() {
         }
     }
 
+    private fun stopFocusTimer() {
+        focusTimer?.cancel()
+        focusTimer = null
+        Timber.tag(TAG).d("Focus 타이머 중지 ${this@PomodoroTimerService.hashCode()}")
+    }
+
     private fun stopRestTimer() {
         restTimer?.cancel()
         restTimer = null
-        Timber.tag(TAG).d("Rest 타이머 중지")
+        Timber.tag(TAG).d("Rest 타이머 중지 ${this@PomodoroTimerService.hashCode()}")
+    }
+
+    private fun createNotification(isFocus: Boolean): Notification {
+        val notificationChannelId = POMODORO_NOTIFICATION_CHANNEL_ID
+        val notificationChannel = NotificationChannel(
+            /* id = */
+            notificationChannelId,
+            /* name = */
+            POMODORO_NOTIFICATION_CHANNEL_NAME,
+            /* importance = */
+            NotificationManager.IMPORTANCE_DEFAULT
+        )
+        notificationManager.createNotificationChannel(notificationChannel)
+
+        return notificationBuilder
+            .setContentText(if (isFocus) "집중 시간이다냥" else "휴식 시간이다냥")
+            .build().apply {
+                flags = Notification.FLAG_NO_CLEAR
+            }
     }
 
     companion object {

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerService.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerService.kt
@@ -67,23 +67,24 @@ class PomodoroTimerService : Service() {
     }
 
     private fun startFocusTimer(maxTime: Int) {
-        focusTimer?.cancel()
-        var focusTimeElapsed = 0
-        focusTimer = fixedRateTimer(initialDelay = TIMER_DELAY, period = TIMER_DELAY) {
-            scope.launch {
-                focusTimeElapsed += ONE_SECOND
+        if (focusTimer == null) {
+            var focusTimeElapsed = 0
+            focusTimer = fixedRateTimer(initialDelay = TIMER_DELAY, period = TIMER_DELAY) {
+                scope.launch {
+                    focusTimeElapsed += ONE_SECOND
 
-                if (focusTimeElapsed == maxTime) {
-                    Timber.d("Focus 타이머가 maxTime $maxTime 에 도달하여 집중 끝 알림 발송")
-                    notifyFocusEnd(this@PomodoroTimerService)
-                }
+                    if (focusTimeElapsed == maxTime) {
+                        Timber.tag(TAG).d("Focus 타이머가 maxTime $maxTime 에 도달하여 집중 끝 알림 발송")
+                        notifyFocusEnd(this@PomodoroTimerService)
+                    }
 
-                if (focusTimeElapsed > maxTime + MAX_EXCEEDED_TIME) {
-                    Timber.d("Focus 타이머가 최대 머무를 수 있는 ${maxTime + MAX_EXCEEDED_TIME} 에 도달하여 중지됨")
-                    stopFocusTimer()
-                } else {
-                    Timber.d("Focus 타이머 작동 중 / 경과 시간: $focusTimeElapsed")
-                    pomodoroTimerRepository.incrementFocusedTime()
+                    if (focusTimeElapsed > maxTime + MAX_EXCEEDED_TIME) {
+                        Timber.tag(TAG).d("Focus 타이머가 최대 머무를 수 있는 ${maxTime + MAX_EXCEEDED_TIME} 에 도달하여 중지됨")
+                        stopFocusTimer()
+                    } else {
+                        Timber.tag(TAG).d("Focus 타이머 작동 중 / 경과 시간: $focusTimeElapsed")
+                        pomodoroTimerRepository.incrementFocusedTime()
+                    }
                 }
             }
         }
@@ -92,27 +93,28 @@ class PomodoroTimerService : Service() {
     private fun stopFocusTimer() {
         focusTimer?.cancel()
         focusTimer = null
-        Timber.d("Focus 타이머 중지")
+        Timber.tag(TAG).d("Focus 타이머 중지")
     }
 
     private fun startRestTimer(maxTime: Int) {
-        restTimer?.cancel()
-        var restTimeElapsed = 0
-        restTimer = fixedRateTimer(initialDelay = TIMER_DELAY, period = TIMER_DELAY) {
-            scope.launch {
-                restTimeElapsed += ONE_SECOND
+        if (restTimer == null) {
+            var restTimeElapsed = 0
+            restTimer = fixedRateTimer(initialDelay = TIMER_DELAY, period = TIMER_DELAY) {
+                scope.launch {
+                    restTimeElapsed += ONE_SECOND
 
-                if (restTimeElapsed == maxTime) {
-                    Timber.d("Rest 타이머가 maxTime $maxTime 에 도달하여 휴식 끝 알림 발송")
-                    notifyRestEnd(this@PomodoroTimerService)
-                }
+                    if (restTimeElapsed == maxTime) {
+                        Timber.tag(TAG).d("Rest 타이머가 maxTime $maxTime 에 도달하여 휴식 끝 알림 발송")
+                        notifyRestEnd(this@PomodoroTimerService)
+                    }
 
-                if (restTimeElapsed > maxTime + MAX_EXCEEDED_TIME) {
-                    Timber.d("Rest 타이머가 최대 머무를 수 있는 ${maxTime + MAX_EXCEEDED_TIME} 에 도달하여 중지됨")
-                    stopRestTimer()
-                } else {
-                    Timber.d("Rest 타이머 작동 중 / 경과 시간: $restTimeElapsed")
-                    pomodoroTimerRepository.incrementRestedTime()
+                    if (restTimeElapsed > maxTime + MAX_EXCEEDED_TIME) {
+                        Timber.tag(TAG).d("Rest 타이머가 최대 머무를 수 있는 ${maxTime + MAX_EXCEEDED_TIME} 에 도달하여 중지됨")
+                        stopRestTimer()
+                    } else {
+                        Timber.tag(TAG).d("Rest 타이머 작동 중 / 경과 시간: $restTimeElapsed")
+                        pomodoroTimerRepository.incrementRestedTime()
+                    }
                 }
             }
         }
@@ -121,7 +123,7 @@ class PomodoroTimerService : Service() {
     private fun stopRestTimer() {
         restTimer?.cancel()
         restTimer = null
-        Timber.d("Rest 타이머 중지")
+        Timber.tag(TAG).d("Rest 타이머 중지")
     }
 
     companion object {

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerService.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerService.kt
@@ -1,0 +1,86 @@
+package com.pomonyang.mohanyang.presentation.util
+
+import android.app.Service
+import android.content.Intent
+import android.os.IBinder
+import com.pomonyang.mohanyang.data.repository.pomodoro.PomodoroTimerRepository
+import com.pomonyang.mohanyang.domain.usecase.InsertPomodoroInitialDataUseCase
+import dagger.hilt.android.AndroidEntryPoint
+import java.util.*
+import javax.inject.Inject
+import kotlin.concurrent.fixedRateTimer
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+private enum class TimerKind {
+    FOCUS,
+    REST
+}
+
+@AndroidEntryPoint
+class PomodoroTimerService : Service() {
+
+    @Inject
+    lateinit var pomodoroTimerRepository: PomodoroTimerRepository
+
+    @Inject
+    lateinit var pomodoroInitialDataUseCase: InsertPomodoroInitialDataUseCase
+
+    private lateinit var timerKind: TimerKind
+    private lateinit var timer: Timer
+
+    private var scope = CoroutineScope(Dispatchers.IO)
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+        val type = intent.getBooleanExtra(PomodoroTimerServiceExtras.INTENT_TIMER_KIND, true)
+        val action = intent.action
+        timerKind = when (type) {
+            true -> {
+                TimerKind.FOCUS
+            }
+
+            false -> {
+                TimerKind.REST
+            }
+        }
+
+        when (action) {
+            PomodoroTimerServiceExtras.ACTION_TIMER_START -> startTimer()
+            PomodoroTimerServiceExtras.ACTION_TIMER_STOP -> stopTimer()
+        }
+
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    private fun startTimer() {
+        scope.launch {
+            pomodoroInitialDataUseCase()
+        }
+        timer = fixedRateTimer(initialDelay = TIMER_DELAY, period = TIMER_DELAY) {
+            scope.launch {
+                when (timerKind) {
+                    TimerKind.FOCUS -> {
+                        pomodoroTimerRepository.incrementFocusedTime()
+                    }
+
+                    TimerKind.REST -> {
+                        pomodoroTimerRepository.incrementRestedTime()
+                    }
+                }
+            }
+        }
+    }
+
+    private fun stopTimer() {
+        if (this::timer.isInitialized) {
+            timer.cancel()
+        }
+    }
+
+    companion object {
+        private const val TIMER_DELAY = 1000L
+    }
+}

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerService.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerService.kt
@@ -67,24 +67,23 @@ class PomodoroTimerService : Service() {
     }
 
     private fun startFocusTimer(maxTime: Int) {
-        if (focusTimer == null) {
-            var focusTimeElapsed = 0
-            focusTimer = fixedRateTimer(initialDelay = TIMER_DELAY, period = TIMER_DELAY) {
-                scope.launch {
-                    focusTimeElapsed += ONE_SECOND
+        focusTimer?.cancel()
+        var focusTimeElapsed = 0
+        focusTimer = fixedRateTimer(initialDelay = TIMER_DELAY, period = TIMER_DELAY) {
+            scope.launch {
+                focusTimeElapsed += ONE_SECOND
 
-                    if (focusTimeElapsed == maxTime) {
-                        Timber.d("Focus 타이머가 maxTime $maxTime 에 도달하여 집중 끝 알림 발송")
-                        notifyFocusEnd(this@PomodoroTimerService)
-                    }
+                if (focusTimeElapsed == maxTime) {
+                    Timber.d("Focus 타이머가 maxTime $maxTime 에 도달하여 집중 끝 알림 발송")
+                    notifyFocusEnd(this@PomodoroTimerService)
+                }
 
-                    if (focusTimeElapsed > maxTime + MAX_EXCEEDED_TIME) {
-                        Timber.d("Focus 타이머가 최대 머무를 수 있는 ${maxTime + MAX_EXCEEDED_TIME} 에 도달하여 중지됨")
-                        stopFocusTimer()
-                    } else {
-                        Timber.d("Focus 타이머 작동 중 / 경과 시간: $focusTimeElapsed")
-                        pomodoroTimerRepository.incrementFocusedTime()
-                    }
+                if (focusTimeElapsed > maxTime + MAX_EXCEEDED_TIME) {
+                    Timber.d("Focus 타이머가 최대 머무를 수 있는 ${maxTime + MAX_EXCEEDED_TIME} 에 도달하여 중지됨")
+                    stopFocusTimer()
+                } else {
+                    Timber.d("Focus 타이머 작동 중 / 경과 시간: $focusTimeElapsed")
+                    pomodoroTimerRepository.incrementFocusedTime()
                 }
             }
         }
@@ -97,24 +96,23 @@ class PomodoroTimerService : Service() {
     }
 
     private fun startRestTimer(maxTime: Int) {
-        if (restTimer == null) {
-            var restTimeElapsed = 0
-            restTimer = fixedRateTimer(initialDelay = TIMER_DELAY, period = TIMER_DELAY) {
-                scope.launch {
-                    restTimeElapsed += ONE_SECOND
+        restTimer?.cancel()
+        var restTimeElapsed = 0
+        restTimer = fixedRateTimer(initialDelay = TIMER_DELAY, period = TIMER_DELAY) {
+            scope.launch {
+                restTimeElapsed += ONE_SECOND
 
-                    if (restTimeElapsed == maxTime) {
-                        Timber.d("Rest 타이머가 maxTime $maxTime 에 도달하여 휴식 끝 알림 발송")
-                        notifyRestEnd(this@PomodoroTimerService)
-                    }
+                if (restTimeElapsed == maxTime) {
+                    Timber.d("Rest 타이머가 maxTime $maxTime 에 도달하여 휴식 끝 알림 발송")
+                    notifyRestEnd(this@PomodoroTimerService)
+                }
 
-                    if (restTimeElapsed > maxTime + MAX_EXCEEDED_TIME) {
-                        Timber.d("Rest 타이머가 최대 머무를 수 있는 ${maxTime + MAX_EXCEEDED_TIME} 에 도달하여 중지됨")
-                        stopRestTimer()
-                    } else {
-                        Timber.d("Rest 타이머 작동 중 / 경과 시간: $restTimeElapsed")
-                        pomodoroTimerRepository.incrementRestedTime()
-                    }
+                if (restTimeElapsed > maxTime + MAX_EXCEEDED_TIME) {
+                    Timber.d("Rest 타이머가 최대 머무를 수 있는 ${maxTime + MAX_EXCEEDED_TIME} 에 도달하여 중지됨")
+                    stopRestTimer()
+                } else {
+                    Timber.d("Rest 타이머 작동 중 / 경과 시간: $restTimeElapsed")
+                    pomodoroTimerRepository.incrementRestedTime()
                 }
             }
         }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerService.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerService.kt
@@ -5,7 +5,10 @@ import android.content.Intent
 import android.os.IBinder
 import com.pomonyang.mohanyang.data.repository.pomodoro.PomodoroTimerRepository
 import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.MAX_EXCEEDED_TIME
+import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.ONE_SECOND
 import com.pomonyang.mohanyang.presentation.screen.PomodoroConstants.TIMER_DELAY
+import com.pomonyang.mohanyang.presentation.util.MnNotificationManager.notifyFocusEnd
+import com.pomonyang.mohanyang.presentation.util.MnNotificationManager.notifyRestEnd
 import dagger.hilt.android.AndroidEntryPoint
 import java.util.*
 import javax.inject.Inject
@@ -26,17 +29,14 @@ class PomodoroTimerService : Service() {
 
     private var scope = CoroutineScope(Dispatchers.IO)
 
-    private var focusTimeElapsed = 0 // 초 단위로 경과된 시간 저장
-    private var restTimeElapsed = 0 // 초 단위로 경과된 시간 저장
-
     override fun onBind(intent: Intent?): IBinder? = null
 
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
         val isFocus = intent.getBooleanExtra(PomodoroTimerServiceExtras.INTENT_TIMER_IS_FOCUS, true)
-        val maxTime = intent.getIntExtra(PomodoroTimerServiceExtras.INTENT_TIMER_MAX_TIME, 0) // maxTime은 초 단위로 전달
+        val maxTime = intent.getIntExtra(PomodoroTimerServiceExtras.INTENT_TIMER_MAX_TIME, 0)
         val action = intent.action
 
-        Timber.d("[지훈] ${object {}.javaClass.enclosingMethod?.name} isFocus $isFocus / $action")
+        Timber.tag(TAG).d("isFocus $isFocus / maxTime $maxTime / $action")
 
         when (action) {
             PomodoroTimerServiceExtras.ACTION_TIMER_START -> {
@@ -60,6 +60,7 @@ class PomodoroTimerService : Service() {
     }
 
     override fun stopService(name: Intent?): Boolean {
+        Timber.tag(TAG).d("stopService")
         stopFocusTimer()
         stopRestTimer()
         return super.stopService(name)
@@ -67,16 +68,21 @@ class PomodoroTimerService : Service() {
 
     private fun startFocusTimer(maxTime: Int) {
         if (focusTimer == null) {
-            focusTimeElapsed = 0
+            var focusTimeElapsed = 0
             focusTimer = fixedRateTimer(initialDelay = TIMER_DELAY, period = TIMER_DELAY) {
                 scope.launch {
-                    focusTimeElapsed += (TIMER_DELAY / TIMER_DELAY).toInt() // 경과 시간 누적 (TIMER_DELAY는 밀리초이므로 초 단위로 변환)
+                    focusTimeElapsed += ONE_SECOND
+
+                    if (focusTimeElapsed == maxTime) {
+                        Timber.d("Focus 타이머가 maxTime $maxTime 에 도달하여 집중 끝 알림 발송")
+                        notifyFocusEnd(this@PomodoroTimerService)
+                    }
 
                     if (focusTimeElapsed > maxTime + MAX_EXCEEDED_TIME) {
-                        Timber.d("[지훈] Focus 타이머가 maxTime $maxTime 에 도달하여 중지됨")
+                        Timber.d("Focus 타이머가 최대 머무를 수 있는 ${maxTime + MAX_EXCEEDED_TIME} 에 도달하여 중지됨")
                         stopFocusTimer()
                     } else {
-                        Timber.d("[지훈] Focus 타이머 작동 중 / 경과 시간: $focusTimeElapsed")
+                        Timber.d("Focus 타이머 작동 중 / 경과 시간: $focusTimeElapsed")
                         pomodoroTimerRepository.incrementFocusedTime()
                     }
                 }
@@ -87,20 +93,26 @@ class PomodoroTimerService : Service() {
     private fun stopFocusTimer() {
         focusTimer?.cancel()
         focusTimer = null
-        Timber.d("[지훈] Focus 타이머 중지")
+        Timber.d("Focus 타이머 중지")
     }
 
     private fun startRestTimer(maxTime: Int) {
         if (restTimer == null) {
-            restTimeElapsed = 0
+            var restTimeElapsed = 0
             restTimer = fixedRateTimer(initialDelay = TIMER_DELAY, period = TIMER_DELAY) {
                 scope.launch {
-                    restTimeElapsed += (TIMER_DELAY / TIMER_DELAY).toInt() // 경과 시간 누적 (TIMER_DELAY는 밀리초이므로 초 단위로 변환)
+                    restTimeElapsed += ONE_SECOND
+
+                    if (restTimeElapsed == maxTime) {
+                        Timber.d("Rest 타이머가 maxTime $maxTime 에 도달하여 휴식 끝 알림 발송")
+                        notifyRestEnd(this@PomodoroTimerService)
+                    }
+
                     if (restTimeElapsed > maxTime + MAX_EXCEEDED_TIME) {
-                        Timber.d("[지훈] Rest 타이머가 maxTime $maxTime 에 도달하여 중지됨")
+                        Timber.d("Rest 타이머가 최대 머무를 수 있는 ${maxTime + MAX_EXCEEDED_TIME} 에 도달하여 중지됨")
                         stopRestTimer()
                     } else {
-                        Timber.d("[지훈] Rest 타이머 작동 중 / 경과 시간: $restTimeElapsed")
+                        Timber.d("Rest 타이머 작동 중 / 경과 시간: $restTimeElapsed")
                         pomodoroTimerRepository.incrementRestedTime()
                     }
                 }
@@ -111,6 +123,10 @@ class PomodoroTimerService : Service() {
     private fun stopRestTimer() {
         restTimer?.cancel()
         restTimer = null
-        Timber.d("[지훈] Rest 타이머 중지")
+        Timber.d("Rest 타이머 중지")
+    }
+
+    companion object {
+        private const val TAG = "PomodoroTimerService"
     }
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerServiceExtras.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerServiceExtras.kt
@@ -1,0 +1,8 @@
+package com.pomonyang.mohanyang.presentation.util
+
+object PomodoroTimerServiceExtras {
+
+    const val INTENT_TIMER_KIND = "mohanyang.intent.TIMER_KIND"
+    const val ACTION_TIMER_START = "mohanyang.action.TIMER_START"
+    const val ACTION_TIMER_STOP = "mohanyang.action.TIMER_STOP"
+}

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerServiceExtras.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerServiceExtras.kt
@@ -1,8 +1,8 @@
 package com.pomonyang.mohanyang.presentation.util
 
 object PomodoroTimerServiceExtras {
-
     const val INTENT_TIMER_IS_FOCUS = "mohanyang.intent.TIMER_FOCUS"
+    const val INTENT_TIMER_MAX_TIME = "mohanyang.intent.MAX_TIME"
     const val ACTION_TIMER_START = "mohanyang.action.TIMER_START"
     const val ACTION_TIMER_STOP = "mohanyang.action.TIMER_STOP"
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerServiceExtras.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/PomodoroTimerServiceExtras.kt
@@ -2,7 +2,7 @@ package com.pomonyang.mohanyang.presentation.util
 
 object PomodoroTimerServiceExtras {
 
-    const val INTENT_TIMER_KIND = "mohanyang.intent.TIMER_KIND"
+    const val INTENT_TIMER_IS_FOCUS = "mohanyang.intent.TIMER_FOCUS"
     const val ACTION_TIMER_START = "mohanyang.action.TIMER_START"
     const val ACTION_TIMER_STOP = "mohanyang.action.TIMER_STOP"
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/TimerUtils.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/TimerUtils.kt
@@ -2,12 +2,18 @@ package com.pomonyang.mohanyang.presentation.util
 
 import android.content.Context
 import android.content.Intent
+import androidx.core.os.bundleOf
 
-fun Context.startTimer(isFocus: Boolean) {
+fun Context.startTimer(isFocus: Boolean, maxTime: Int) {
     startService(
         Intent(this, PomodoroTimerService::class.java).apply {
             action = PomodoroTimerServiceExtras.ACTION_TIMER_START
-            putExtra(PomodoroTimerServiceExtras.INTENT_TIMER_IS_FOCUS, isFocus)
+            putExtras(
+                bundleOf(
+                    PomodoroTimerServiceExtras.INTENT_TIMER_IS_FOCUS to isFocus,
+                    PomodoroTimerServiceExtras.INTENT_TIMER_MAX_TIME to maxTime
+                )
+            )
         }
     )
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/TimerUtils.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/util/TimerUtils.kt
@@ -1,0 +1,22 @@
+package com.pomonyang.mohanyang.presentation.util
+
+import android.content.Context
+import android.content.Intent
+
+fun Context.startTimer(isFocus: Boolean) {
+    startService(
+        Intent(this, PomodoroTimerService::class.java).apply {
+            action = PomodoroTimerServiceExtras.ACTION_TIMER_START
+            putExtra(PomodoroTimerServiceExtras.INTENT_TIMER_IS_FOCUS, isFocus)
+        }
+    )
+}
+
+fun Context.stopTimer(isFocus: Boolean) {
+    startService(
+        Intent(this, PomodoroTimerService::class.java).apply {
+            action = PomodoroTimerServiceExtras.ACTION_TIMER_STOP
+            putExtra(PomodoroTimerServiceExtras.INTENT_TIMER_IS_FOCUS, isFocus)
+        }
+    )
+}


### PR DESCRIPTION
## 작업 내용

- Timer 관련 Service 구현
- Timer 의 전반적인 Model을 갖고 있는 SharedViewModel 추가
  - Rest / Focus의 각각의 ViewModel: 클릭 등 각 Screen의 고유한 상태 및 이벤트 관리
  - TimerViewModel: Timer에 대한 상태 및 전반적인 이벤트 관리

## 체크리스트
- [x] 빌드 확인
- [x] 포커스 / 휴식 타이머 정상 동작 확인
- [x] 포커스 화면에서 특정 시간 (릴리즈 60분 / 디버그 5초?)지난 후 휴식 대기 화면으로 이동 되는지
- [x] 휴식 대기 화면에서 특정 시간(릴리즈 60분 / 디버그 10초) 이 지난 후 강제로 홈화면 이동 후 다이얼로그 뜨는지
- [x] 휴식이 끝나면 Room 에서 데이터 정상적으로 제거가 되는지

## 동작 화면

전체적으로 화면은 똑같아서 첨부는 안했읍니다

## 살려주세요

