### PR TITLE
[SCRUM-54] 잠금화면 타이머 노출 옵션 기능 구현

### DIFF
--- a/data/src/main/java/com/pomonyang/mohanyang/data/local/datastore/datasource/notification/NotificationLocalDataSource.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/local/datastore/datasource/notification/NotificationLocalDataSource.kt
@@ -3,6 +3,8 @@ package com.pomonyang.mohanyang.data.local.datastore.datasource.notification
 interface NotificationLocalDataSource {
     suspend fun saveInterruptNotification(isEnabled: Boolean)
     suspend fun saveTimerNotification(isEnabled: Boolean)
+    suspend fun saveLockScreenNotification(isEnabled: Boolean)
     suspend fun isInterruptNotificationEnabled(): Boolean
     suspend fun isTimerNotification(): Boolean
+    suspend fun isLockScreenNotification(): Boolean
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/local/datastore/datasource/notification/NotificationLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/local/datastore/datasource/notification/NotificationLocalDataSourceImpl.kt
@@ -26,6 +26,13 @@ class NotificationLocalDataSourceImpl @Inject constructor(
         }
     }
 
+    override suspend fun saveLockScreenNotification(isEnabled: Boolean) {
+        dataStore.edit { preferences ->
+            preferences[LOCKSCREEN_NOTIFICATION_KEY] = isEnabled
+        }
+    }
+
+
     override suspend fun isInterruptNotificationEnabled(): Boolean = dataStore.data
         .catch { exception ->
             if (exception is IOException) {
@@ -44,9 +51,21 @@ class NotificationLocalDataSourceImpl @Inject constructor(
             }
         }.first()[TIMER_NOTIFICATION_KEY] ?: false
 
+    override suspend fun isLockScreenNotification(): Boolean = dataStore.data
+        .catch { exception ->
+            if (exception is IOException) {
+                emit(emptyPreferences())
+            } else {
+                throw exception
+            }
+        }.first()[LOCKSCREEN_NOTIFICATION_KEY] ?: true
+
+
     companion object {
         const val NOTIFICATION_PREFERENCES_NAME = "notification_preferences"
         private val INTERRUPT_NOTIFICATION_KEY = booleanPreferencesKey("interrupt_notification")
         private val TIMER_NOTIFICATION_KEY = booleanPreferencesKey("timer_notification")
+        private val LOCKSCREEN_NOTIFICATION_KEY = booleanPreferencesKey("lockscreen_notification")
+
     }
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/push/PushAlarmRepository.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/push/PushAlarmRepository.kt
@@ -11,4 +11,6 @@ interface PushAlarmRepository {
     suspend fun isInterruptNotificationEnabled(): Boolean
     suspend fun setTimerNotification(isEnabled: Boolean)
     suspend fun isTimerNotificationEnabled(): Boolean
+    suspend fun isLockScreenNotificationEnabled(): Boolean
+    suspend fun setLockScreenNotification(isEnabled: Boolean)
 }

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/push/PushAlarmRepositoryImpl.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/push/PushAlarmRepositoryImpl.kt
@@ -30,6 +30,10 @@ internal class PushAlarmRepositoryImpl @Inject constructor(
 
     override suspend fun isTimerNotificationEnabled(): Boolean = notificationLocalDataSource.isTimerNotification()
 
+    override suspend fun isLockScreenNotificationEnabled(): Boolean = notificationLocalDataSource.isLockScreenNotification()
+
+    override suspend fun setLockScreenNotification(isEnabled: Boolean) = notificationLocalDataSource.saveLockScreenNotification(isEnabled)
+
     companion object {
         private const val DEVICE_TYPE = "ANDROID"
     }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/noti/PomodoroNotificationManager.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/noti/PomodoroNotificationManager.kt
@@ -24,14 +24,13 @@ import kotlinx.coroutines.runBlocking
 
 internal class PomodoroNotificationManager @Inject constructor(
     @ApplicationContext private val context: Context,
-    @PomodoroNotification private val notificationBuilder: NotificationCompat.Builder,
     private val pushAlarmRepository: PushAlarmRepository,
+    @PomodoroNotification private val notificationBuilder: NotificationCompat.Builder,
     private val notificationManager: NotificationManager,
     private val contentFactory: PomodoroNotificationContentFactory
 ) {
 
-
-    private var lockScreenVisibility: Int = NotificationManager.IMPORTANCE_LOW;
+    private var lockScreenVisibility: Int = NotificationCompat.VISIBILITY_PUBLIC;
 
     init {
         lockScreenVisibility = getLockScreenVisibility()

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/noti/PomodoroNotificationManager.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/noti/PomodoroNotificationManager.kt
@@ -30,10 +30,10 @@ internal class PomodoroNotificationManager @Inject constructor(
     private val contentFactory: PomodoroNotificationContentFactory
 ) {
 
-    private var lockScreenVisibility: Int = NotificationCompat.VISIBILITY_PUBLIC;
+    private var lockScreenVisibility: Int = NotificationCompat.VISIBILITY_PUBLIC
 
     init {
-        lockScreenVisibility = getLockScreenVisibility()
+        updateLockScreenVisibility()
         createNotificationChannel()
     }
 
@@ -58,8 +58,7 @@ internal class PomodoroNotificationManager @Inject constructor(
         val defaultTime = context.getString(R.string.notification_timer_default_time)
         val contentView = createContentView(isRest)
         val bigContentView = createBigContentView(category, defaultTime, null)
-        lockScreenVisibility = getLockScreenVisibility()
-
+        updateLockScreenVisibility()
         return buildNotification(contentView, bigContentView, lockScreenVisibility)
     }
 
@@ -102,6 +101,10 @@ internal class PomodoroNotificationManager @Inject constructor(
         } else {
             NotificationCompat.VISIBILITY_SECRET
         }
+    }
+
+    private fun updateLockScreenVisibility() {
+        lockScreenVisibility = getLockScreenVisibility()
     }
 
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/mypage/MyPageElements.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/mypage/MyPageElements.kt
@@ -7,7 +7,8 @@ import com.pomonyang.mohanyang.presentation.base.ViewState
 data class MyPageState(
     val catName: String = "",
     val isInterruptNotificationEnabled: Boolean = false,
-    val isTimerNotificationEnabled: Boolean = false
+    val isTimerNotificationEnabled: Boolean = false,
+    val isLockScreenNotificationEnabled: Boolean = false,
 ) : ViewState
 
 sealed interface MyPageEvent : ViewEvent {
@@ -15,6 +16,7 @@ sealed interface MyPageEvent : ViewEvent {
     data class ClickCatProfile(val isOffline: Boolean) : MyPageEvent
     data class ChangeInterruptNotification(val isEnabled: Boolean) : MyPageEvent
     data class ChangeTimerNotification(val isEnabled: Boolean) : MyPageEvent
+    data class ChangeLockScreenNotification(val isEnabled: Boolean) : MyPageEvent
     data object CloseDialog : MyPageEvent
     data object OpenSetting : MyPageEvent
     data object ClickSuggestion : MyPageEvent

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/mypage/MyPageScreen.kt
@@ -357,6 +357,11 @@ fun NotificationBox(
                     onAction(MyPageEvent.ChangeInterruptNotification(isEnabled))
                 }
             )
+            LockScreenNotificationBox(
+                isChecked = state.isLockScreenNotificationEnabled,
+                onChangeValue = { isEnabled ->
+                    onAction(MyPageEvent.ChangeLockScreenNotification(isEnabled))
+                })
         }
     }
 }
@@ -413,6 +418,36 @@ fun InterruptNotificationBox(
             )
             Text(
                 text = stringResource(id = R.string.my_page_interrupt_push_content),
+                color = MnTheme.textColorScheme.tertiary,
+                style = MnTheme.typography.subBodyRegular
+            )
+        }
+        MnToggleButton(isChecked = isChecked, onCheckedChange = onChangeValue)
+    }
+}
+
+@Composable
+fun LockScreenNotificationBox(
+    modifier: Modifier = Modifier,
+    isChecked: Boolean,
+    onChangeValue: (Boolean) -> Unit
+) {
+    Row(
+        modifier = modifier.padding(MnSpacing.xLarge),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(MnSpacing.small)
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(MnSpacing.xSmall),
+            modifier = Modifier.weight(1f)
+        ) {
+            Text(
+                text = stringResource(id = R.string.my_page_lockscreen_push_title),
+                color = MnTheme.textColorScheme.primary,
+                style = MnTheme.typography.header4
+            )
+            Text(
+                text = stringResource(id = R.string.my_page_lockscreen_push_content),
                 color = MnTheme.textColorScheme.tertiary,
                 style = MnTheme.typography.subBodyRegular
             )

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/mypage/MyPageScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/mypage/MyPageScreen.kt
@@ -88,6 +88,10 @@ fun MyPageRoute(
                     NotificationRequest.INTERRUPT -> {
                         myPageViewModel.handleEvent(MyPageEvent.ChangeInterruptNotification(true))
                     }
+
+                    NotificationRequest.LOCKSCREEN -> {
+                        myPageViewModel.handleEvent(MyPageEvent.ChangeLockScreenNotification(true))
+                    }
                 }
             }
         }
@@ -147,7 +151,7 @@ fun MyPageRoute(
     )
 }
 
-enum class NotificationRequest { TIMER, INTERRUPT }
+enum class NotificationRequest { TIMER, INTERRUPT, LOCKSCREEN }
 
 @Composable
 fun MyPageScreen(

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/mypage/MyPageViewModel.kt
@@ -48,6 +48,10 @@ class MyPageViewModel @Inject constructor(
                 )
             }
 
+            is MyPageEvent.ChangeLockScreenNotification -> {
+                setLockScreenNotification(event.isEnabled)
+            }
+
             is MyPageEvent.CloseDialog -> {
                 setEffect(MyPageSideEffect.CloseDialog)
             }
@@ -80,18 +84,27 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
+    private fun setLockScreenNotification(isEnabled: Boolean) {
+        viewModelScope.launch {
+            pushAlarmRepository.setLockScreenNotification(isEnabled)
+            updateState { copy(isLockScreenNotificationEnabled = isEnabled) }
+        }
+    }
+
     private fun getUserProfile(appNotificationGranted: Boolean) {
         viewModelScope.launch {
             val userInfo = userRepository.getMyInfo()
 
             val isInterruptEnabled = appNotificationGranted && pushAlarmRepository.isInterruptNotificationEnabled()
             val isTimerEnabled = appNotificationGranted && pushAlarmRepository.isTimerNotificationEnabled()
+            val isLockScreenEnabled = appNotificationGranted && pushAlarmRepository.isLockScreenNotificationEnabled()
 
             updateState {
                 copy(
                     catName = userInfo.cat.name,
                     isInterruptNotificationEnabled = isInterruptEnabled,
-                    isTimerNotificationEnabled = isTimerEnabled
+                    isTimerNotificationEnabled = isTimerEnabled,
+                    isLockScreenNotificationEnabled = isLockScreenEnabled
                 )
             }
         }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/mypage/MyPageViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/mypage/MyPageViewModel.kt
@@ -49,7 +49,12 @@ class MyPageViewModel @Inject constructor(
             }
 
             is MyPageEvent.ChangeLockScreenNotification -> {
-                setLockScreenNotification(event.isEnabled)
+                setEffect(
+                    MyPageSideEffect.CheckNotificationPermission(
+                        request = NotificationRequest.LOCKSCREEN,
+                        onGranted = { setLockScreenNotification(event.isEnabled) }
+                    )
+                )
             }
 
             is MyPageEvent.CloseDialog -> {

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -77,6 +77,8 @@
     <string name="my_page_timer_push_content">"집중・휴식시간이 되면 고양이가 알려줘요"</string>
     <string name="my_page_interrupt_push_title">딴 짓 방해하기</string>
     <string name="my_page_interrupt_push_content">다른 앱을 사용하면 고양이가 방해해요</string>
+    <string name="my_page_lockscreen_push_title">잠금화면 표시하기</string>
+    <string name="my_page_lockscreen_push_content">잠금화면에 집중•휴식시간을 표시해요</string>
     <string name="my_page_suggestion">의견보내기</string>
     <string name="my_page_offline_message">오프라인 모드에서 고양이 변경은 불가능합니다</string>
 
@@ -101,7 +103,6 @@
     <string name="my_page_static_subtitle">통계에서 집중시간을 모아볼 수 있어요</string>
     <string name="my_page_static_check">확인하기</string>
     <string name="my_page_static_check_toast">통계를 사용할 수 있도록 준비하고 있어요</string>
-
 
 
 </resources>


### PR DESCRIPTION
## 작업 내용
- 마이페이지 잠금화면 표시하기 옵션 UI 추가
- 잠금화면 표시 datastore data 추가
- 뽀모도로 서비스 notification setvisiblity 옵션 추가로 잠금화면 옵션 기능 구현

## 체크리스트
- [x] 빌드 확인
- [x] 토글 옵션에 따라 타이머 노출 여부 잘 작동하는 지

## 동작 화면


https://github.com/user-attachments/assets/1ed48c5c-8e57-46bc-92bf-bdeb23425ff7



## 살려주세요

