### PR TITLE
[SCRUM-82] 방해알림 채널 분리 및 알림음 제거

### DIFF
--- a/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
@@ -29,6 +29,7 @@ import com.datadog.android.compose.ExperimentalTrackingApi
 import com.datadog.android.compose.NavigationViewTrackingEffect
 import com.pomonyang.mohanyang.data.remote.util.NetworkMonitor
 import com.pomonyang.mohanyang.notification.LocalNotificationReceiver
+import com.pomonyang.mohanyang.notification.util.createInterruptNotificationChannel
 import com.pomonyang.mohanyang.notification.util.createNotificationChannel
 import com.pomonyang.mohanyang.notification.util.deleteNotificationChannelIfExists
 import com.pomonyang.mohanyang.presentation.screen.common.LoadingScreen
@@ -163,6 +164,7 @@ class MainActivity : ComponentActivity() {
     private fun setupNotification() {
         deletePrevNotificationChannel()
         createNotificationChannel()
+        createInterruptNotificationChannel()
         registerNotificationService()
     }
 

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/FocusNotificationService.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/FocusNotificationService.kt
@@ -85,7 +85,8 @@ class FocusNotificationService : Service() {
 
     private fun addAlarm(time: LocalTime, message: String = "") {
         mnAlarmManager.createAlarm(
-            time,
+            scheduleTime = time,
+            channelId = getString(R.string.interrupt_channel_id),
             title = applicationContext.getString(R.string.app_name),
             message = message
         ).also {

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/LocalNotificationReceiver.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/LocalNotificationReceiver.kt
@@ -14,7 +14,7 @@ import com.pomonyang.mohanyang.presentation.model.cat.CatType
 import com.pomonyang.mohanyang.presentation.util.MnNotificationManager
 import com.pomonyang.mohanyang.ui.ServiceHelper
 import dagger.hilt.android.AndroidEntryPoint
-import java.util.UUID
+import java.util.*
 import javax.inject.Inject
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -43,7 +43,15 @@ class LocalNotificationReceiver @Inject constructor() : BroadcastReceiver() {
                     val notificationId = intent.getIntExtra(context.getString(R.string.local_notification_id), 0)
                     val title = intent.getStringExtra(context.getString(R.string.local_notification_title)) ?: ""
                     val message = intent.getStringExtra(context.getString(R.string.local_notification_message)) ?: ""
-                    notifyMessage(context, notificationId, title, message)
+                    val channelId = intent.getStringExtra(context.getString(R.string.local_notification_channel_id)) ?: context.getString(R.string.channel_id)
+
+                    notifyMessage(
+                        context,
+                        notificationId = notificationId,
+                        channelId = channelId,
+                        title = title,
+                        message = message
+                    )
                 }
 
                 MnNotificationManager.INTENT_NOTIFY_REST_MESSAGE -> {
@@ -52,6 +60,7 @@ class LocalNotificationReceiver @Inject constructor() : BroadcastReceiver() {
                         notifyMessage(
                             context,
                             notificationId = id,
+                            channelId = context.getString(R.string.channel_id),
                             message = context.getString(cat.restEndPushContent)
                         )
                     }
@@ -63,6 +72,7 @@ class LocalNotificationReceiver @Inject constructor() : BroadcastReceiver() {
                         notifyMessage(
                             context,
                             notificationId = id,
+                            channelId = context.getString(R.string.channel_id),
                             message = context.getString(cat.timerEndPushContent)
                         )
                     }
@@ -81,19 +91,25 @@ class LocalNotificationReceiver @Inject constructor() : BroadcastReceiver() {
         }
     }
 
-    private fun notifyMessage(context: Context, notificationId: Int, title: String = context.getString(R.string.app_name), message: String) {
+    private fun notifyMessage(
+        context: Context,
+        notificationId: Int,
+        channelId: String,
+        title: String = context.getString(R.string.app_name),
+        message: String
+    ) {
         if (!context.isNotificationGranted()) return
 
         val pendingIntent = ServiceHelper.clickPendingIntent(context, notificationId)
 
         val notification =
-            context.defaultNotification(pendingIntent)
+            context.defaultNotification(pendingIntent, channelId = channelId)
                 .setContentTitle(title)
                 .setContentText(message)
                 .build()
 
         val summaryNotification =
-            context.summaryNotification(pendingIntent)
+            context.summaryNotification(pendingIntent, channelId = channelId)
                 .setContentTitle(title)
                 .setContentText(message)
                 .build()

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/MnAlarmManager.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/MnAlarmManager.kt
@@ -20,6 +20,7 @@ class MnAlarmManager @Inject constructor(
     @SuppressLint("ScheduleExactAlarm")
     fun createAlarm(
         scheduleTime: LocalTime,
+        channelId: String,
         id: Int = UUID.randomUUID().hashCode(),
         title: String = "",
         message: String = ""
@@ -30,6 +31,7 @@ class MnAlarmManager @Inject constructor(
                     putExtra(getString(R.string.local_notification_id), id)
                     putExtra(getString(R.string.local_notification_title), title)
                     putExtra(getString(R.string.local_notification_message), message)
+                    putExtra(getString(R.string.local_notification_channel_id), channelId)
                     action = MnNotificationManager.INTENT_SEND_MESSAGE
                 }
 

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/MnFirebaseMessagingService.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/MnFirebaseMessagingService.kt
@@ -9,6 +9,7 @@ import androidx.core.app.NotificationManagerCompat
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.pomonyang.mohanyang.MainActivity
+import com.pomonyang.mohanyang.R
 import com.pomonyang.mohanyang.data.repository.push.PushAlarmRepository
 import com.pomonyang.mohanyang.data.repository.user.UserRepository
 import com.pomonyang.mohanyang.notification.util.defaultNotification
@@ -64,7 +65,7 @@ internal class MnFirebaseMessagingService : FirebaseMessagingService() {
             PendingIntent.FLAG_ONE_SHOT or PendingIntent.FLAG_IMMUTABLE // 일회용 펜딩 인텐트
         )
 
-        val builder = applicationContext.defaultNotification(pendingIntent)
+        val builder = applicationContext.defaultNotification(pendingIntent, getString(R.string.channel_id))
 
         builder.apply {
             setContentTitle(notification.title)

--- a/app/src/main/java/com/pomonyang/mohanyang/notification/util/NotificationUtils.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/notification/util/NotificationUtils.kt
@@ -28,15 +28,15 @@ fun Context.createNotificationChannel() {
         ).apply {
             MnNotificationManager.setCustomAlarmSound(applicationContext, this)
         }
-
     notificationManager.createNotificationChannel(channel)
 }
 
 fun Context.defaultNotification(
-    pendingIntent: PendingIntent? = null
+    pendingIntent: PendingIntent? = null,
+    channelId: String
 ): NotificationCompat.Builder = NotificationCompat.Builder(
     this,
-    getString(R.string.channel_id)
+    channelId
 )
     .setContentIntent(pendingIntent)
     .setSmallIcon(R.drawable.ic_app_notification)
@@ -48,7 +48,10 @@ fun Context.defaultNotification(
     .setCategory(NotificationCompat.CATEGORY_MESSAGE)
     .setGroup(getString(R.string.channel_group_name))
 
-fun Context.summaryNotification(pendingIntent: PendingIntent? = null): NotificationCompat.Builder = this.defaultNotification(pendingIntent)
+fun Context.summaryNotification(
+    pendingIntent: PendingIntent? = null,
+    channelId: String
+): NotificationCompat.Builder = this.defaultNotification(pendingIntent, channelId)
     .setGroupSummary(true)
 
 fun getTriggerTimeInMillis(time: LocalTime): Long {
@@ -69,4 +72,22 @@ fun Context.deleteNotificationChannelIfExists(channelId: String) {
     if (existingChannel != null) {
         notificationManager.deleteNotificationChannel(channelId)
     }
+}
+
+fun Context.createInterruptNotificationChannel() {
+    val notificationManager =
+        applicationContext.getSystemService(NOTIFICATION_SERVICE) as NotificationManager
+
+    val channelId = applicationContext.getString(R.string.interrupt_channel_id)
+    val channelName = applicationContext.getString(R.string.interrupt_channel_name)
+
+    val channel =
+        NotificationChannel(
+            channelId,
+            channelName,
+            NotificationManager.IMPORTANCE_HIGH
+        ).apply {
+            setSound(null, null)
+        }
+    notificationManager.createNotificationChannel(channel)
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="channel_id">moha-nyang-channel-v2</string>
     <string name="channel_name">moha-nyang</string>
     <string name="channel_group_name">moha-nyang-pomodoro</string>
+    <string name="local_notification_channel_id">local_notification_channel_id</string>
     <string name="local_notification_id">local_notification_id</string>
     <string name="local_notification_title">local_notification_title</string>
     <string name="local_notification_message">local_notification_message</string>
@@ -11,5 +12,6 @@
     <string name="force_home_dialog_subtitle">너무 오랜 시간동안 대기화면에 머물러서 홈화면으로 이동되었어요.</string>
     <string name="channel_id_v1">moha-nyang-channel</string>
     <string name="pomodoro_channel_id_v1">pomodoro_notification_channel_id</string>
-
+    <string name="interrupt_channel_id">interrupt_notification_channel_id</string>
+    <string name="interrupt_channel_name">interrupt_notification_channel_name</string>
 </resources>


### PR DESCRIPTION
## 작업 내용
- 기존 기본 알림 채널을 이용하던 방해 알림을 방해알림 채널을 새로 만들어서 분리하였습니다
- 변경 후 : 기본(FCM) / 방해알림 / 타이머 알림
- 방해 알림을 소리X ,진동 X 처리

## 체크리스트
- [x] 빌드 확인
- [x] 방해 알림 무음으로 변경되었는 지 확인 (시스템 알림음 활성화에 상관없이)
- [x] 타이머 알림은 커스텀으로 잘 오는 지 확인

## 동작 화면
- 변경 사항 없음

## 살려주세요

