### PR TITLE
[SCRUM-73] MnDialog close btn 옵션 추가 및 기본값 제거

### DIFF
--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/dialog/MnDialog.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/designsystem/dialog/MnDialog.kt
@@ -43,6 +43,7 @@ fun MnDialog(
     subTitle: String? = null,
     positiveButton: @Composable (() -> Unit)? = null,
     negativeButton: @Composable (() -> Unit)? = null,
+    onCloseClick: (() -> Unit)? = null,
     onDismissRequest: () -> Unit
 ) {
     MnTheme {
@@ -62,7 +63,12 @@ fun MnDialog(
                         title = title,
                         dialogTextStyles = dialogTextStyles,
                         dialogColors = dialogColors,
-                        onCloseClick = onDismissRequest
+                        onCloseClick = onCloseClick?.let { closeClick ->
+                            {
+                                closeClick()
+                                onDismissRequest()
+                            }
+                        }
                     )
                     DialogDescription(
                         subTitle = subTitle,
@@ -122,10 +128,10 @@ private fun DialogDescription(
 
 @Composable
 private fun DialogTitle(
-    onCloseClick: () -> Unit,
     title: String,
     dialogTextStyles: MnDialogTextStyles,
-    dialogColors: MnDialogColors
+    dialogColors: MnDialogColors,
+    onCloseClick: (() -> Unit)?
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -139,12 +145,14 @@ private fun DialogTitle(
             modifier = Modifier.padding(vertical = 7.5.dp),
             maxLines = 1
         )
-        MnMediumIcon(
-            resourceId = R.drawable.ic_close,
-            modifier = Modifier
-                .padding(8.dp)
-                .clickableSingle(activeRippleEffect = false) { onCloseClick() }
-        )
+        if (onCloseClick != null) {
+            MnMediumIcon(
+                resourceId = R.drawable.ic_close,
+                modifier = Modifier
+                    .padding(8.dp)
+                    .clickableSingle(activeRippleEffect = false) { onCloseClick() }
+            )
+        }
     }
 }
 
@@ -172,6 +180,7 @@ private fun MnDialogPreview() {
                     Text("취소")
                 }
             },
+            onCloseClick = {},
             onDismissRequest = {}
         )
     }


### PR DESCRIPTION
## 작업 내용
- close btn 옵션화
- close btn 기본값 제거 

## 체크리스트
- [x] 빌드 확인

## 동작 화면
![스크린샷 2024-12-07 오후 11 52 50](https://github.com/user-attachments/assets/5c9f6963-978e-405c-a8bb-691b9c2a3f08)
![image](https://github.com/user-attachments/assets/293aa498-4cd4-4e5a-a9a4-052ea3b5af29)

![image](https://github.com/user-attachments/assets/078fd3da-2886-4b16-b227-a1b28c33c8d2)

``` kotlin
@Preview
@Composable
private fun MnDialogPreview() {
    MnTheme {
        MnDialog(
      ....
            onCloseClick = {},
            onDismissRequest = {}
        )
    }
}

@Preview
@Composable
private fun MnDialogOnlyPositiveButtonPreview() {
    MnTheme {
        MnDialog(
            ....
            onDismissRequest = {}
        )
    }
}
```

## 살려주세요

