### PR TITLE
[SCRUM-107] 에러화면 로딩 뷰 적용

### DIFF
--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/time/PomodoroTimeSettingViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/time/PomodoroTimeSettingViewModel.kt
@@ -34,6 +34,7 @@ class PomodoroTimeSettingViewModel @Inject constructor(
                 updateState { copy(isInvalidError = true) }
             }
         }
+        updateState { copy(isLoading = false) }
     }
 
     private val scope = viewModelScope + coroutineExceptionHandler
@@ -85,6 +86,8 @@ class PomodoroTimeSettingViewModel @Inject constructor(
                     initialFocusTime = selectedPomodoroSetting.focusTime,
                     initialRestTime = selectedPomodoroSetting.restTime,
                     isFocus = isFocusTime,
+                    isInternalError = false,
+                    isInvalidError = false,
                     isLoading = false
                 )
             }
@@ -99,7 +102,13 @@ class PomodoroTimeSettingViewModel @Inject constructor(
                 focusTime = state.value.pickFocusTime,
                 restTime = state.value.pickRestTime
             ).getOrThrow()
-            updateState { copy(isLoading = false) }
+            updateState {
+                copy(
+                    isInternalError = false,
+                    isInvalidError = false,
+                    isLoading = false
+                )
+            }
         }
     }
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/naming/OnboardingNamingCatScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/naming/OnboardingNamingCatScreen.kt
@@ -103,14 +103,14 @@ fun OnboardingNamingCatScreen(
         }
     }
 
-    when {
-        state.isInternalError -> ServerErrorScreen(onClickNavigateToHome = onNavToHomeClick)
-        state.isInvalidError -> NetworkErrorScreen(onClickRetry = {
-            onAction(NamingEvent.OnClickRetry)
-        })
+    LoadingContentContainer(isLoading = state.isLoading) {
+        when {
+            state.isInternalError -> ServerErrorScreen(onClickNavigateToHome = onNavToHomeClick)
+            state.isInvalidError -> NetworkErrorScreen(onClickRetry = {
+                onAction(NamingEvent.OnClickRetry)
+            })
 
-        else -> {
-            LoadingContentContainer(isLoading = state.isLoading) {
+            else -> {
                 Column(
                     modifier = modifier
                         .fillMaxSize()

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/naming/OnboardingNamingCatViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/naming/OnboardingNamingCatViewModel.kt
@@ -34,6 +34,7 @@ class OnboardingNamingCatViewModel @Inject constructor(
                 updateState { copy(isInvalidError = true) }
             }
         }
+        updateState { copy(isLoading = false) }
     }
 
     private val scope = viewModelScope + coroutineExceptionHandler
@@ -43,12 +44,12 @@ class OnboardingNamingCatViewModel @Inject constructor(
     override fun handleEvent(event: NamingEvent) {
         when (event) {
             is NamingEvent.OnComplete -> {
-                updateState { copy(isLoading = true, lastRequestAction = event) }
                 scope.launch {
+                    updateState { copy(isLoading = true, lastRequestAction = event) }
                     pomodoroSettingRepository.fetchPomodoroSettingList()
                     updateCatName(event.name)
+                    updateState { copy(isLoading = false) }
                 }
-                updateState { copy(isLoading = false) }
             }
 
             is NamingEvent.OnClickRetry -> {

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/select/OnboardingSelectCatScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/select/OnboardingSelectCatScreen.kt
@@ -92,11 +92,11 @@ fun OnboardingSelectCatRoute(
         onboardingSelectCatViewModel.handleEvent(SelectCatEvent.Init(selectedCatNo))
     }
 
-    when {
-        state.isInvalidError -> NetworkErrorScreen(onClickRetry = { onboardingSelectCatViewModel.handleEvent(SelectCatEvent.OnClickRetry) })
+    LoadingContentContainer(isLoading = state.isLoading) {
+        when {
+            state.isInvalidError -> NetworkErrorScreen(onClickRetry = { onboardingSelectCatViewModel.handleEvent(SelectCatEvent.OnClickRetry) })
 
-        else -> {
-            LoadingContentContainer(isLoading = state.isLoading) {
+            else -> {
                 OnboardingSelectCatScreen(
                     onBackClick = onBackClick,
                     modifier = modifier,


### PR DESCRIPTION
> 다시 시도할 때 화면 전체가 전환되어서 깜빡거림이있어 LoadingContainer안으로 에러 스크린과 앱 스크린 둘다 넣어서 프로그래스바가 보이도록 했습니다
>viewmodel에서 에러 state 처리 부분이 중복되는 로직이 있어서, 저번에 이야기 했던 data class 처리 방안으로 리팩토링을 추후 고려해봐야할 것 같아요

## 작업 내용
- 네트워크 에러화면에서 다시시도 했을 때 로딩 프로그래스바 보이도록 수정

## 체크리스트
- [x] 빌드 확인
- [x] 에러 화면 로딩프로그래스바 확인

## 동작 화면

https://github.com/user-attachments/assets/0ea1671b-69fd-479f-a6d6-600dc774a834


## 살려주세요
