### PR TITLE
fix: 신규 유저 조건 추가

### DIFF
--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/user/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/user/UserRepositoryImpl.kt
@@ -19,7 +19,7 @@ internal class UserRepositoryImpl @Inject constructor(
 ) : UserRepository {
     override suspend fun getDeviceId() = deviceLocalDataStore.getDeviceId()
 
-    override fun isNewUser(): Boolean = runBlocking { tokenLocalDataSource.getAccessToken().isEmpty() }
+    override fun isNewUser(): Boolean = runBlocking { tokenLocalDataSource.getAccessToken().isEmpty() || userLocalDataSource.getUserInfo().isNewUser() }
 
     override suspend fun login(deviceId: String) = authService.getTokenByDeviceId(TokenRequest(deviceId))
 


### PR DESCRIPTION
## 작업 내용
> 발견 버그 이슈
> 1. 온보딩 > 고양이 선택화면 > (미선택) > 앱 종료
> 2. 앱재실행 >(토큰이 저장되어 있음으로) 타이머 화면 실행 > 고양이 이름 없음, 타입 기본값 지정
> 3. 고양이 이름 변경 시 400 에러 (지정된 고양이 타입이 전송되지 않았기 때문)

1 > 2 > 3 순으로 진입 했을 때 오류가 발생
3번 외에도 고양이 타입이 필요한 수정 요청에서는 400에러가 발생할 것임

```
고양이 미지정시 user 정보 response
{
  "registeredDeviceNo": 418,
  "isPushEnabled": false,
  "cat": null
}



이름변경 요청 400 에러 response

{
  "type": "CAT_NOT_FOUND",
  "message": "Cat not found",
  "errorTraceId": "66f69a5e-2f49-4350-999c-14529efce6fa"
}

```


## 변경 및 해결 사항

local에 저장한 userInfo 에서 고양이 타입 미지정시 신규 유저로 판단하도록 조건문 추가

## 체크리스트
- [x] 빌드 확인
- [x] 임시 디바이스 아이디로 넣어서 신규 접속  및 해당 프로세스 체크

## 동작 화면


https://github.com/user-attachments/assets/0ddac755-d663-48e0-9421-e49678ec8886


## 살려주세요

