### PR TITLE
[SCRUM-112] BaseUrl이 BuildType에 맞게 들어갈 수 있게 수정

### DIFF
--- a/build-logic/src/main/java/com/pomonyang/mohanyang/convention/Secrets.kt
+++ b/build-logic/src/main/java/com/pomonyang/mohanyang/convention/Secrets.kt
@@ -9,8 +9,8 @@ internal fun Project.configureSecret() {
     val releasePropertiesName = "release.secrets.properties"
     val debugPropertiedName = "debug.secrets.properties"
     extensions.configure<SecretsPluginExtension> {
-        propertiesFileName = releasePropertiesName
-        defaultPropertiesFileName = debugPropertiedName
+        val isDebug = project.gradle.startParameter.taskNames.any { it.contains("Debug", ignoreCase = true) }
+        propertiesFileName = if (isDebug) debugPropertiedName else releasePropertiesName
         ignoreList.add("keyToIgnore")
         ignoreList.add("sdk.*")
     }


### PR DESCRIPTION
## 작업 내용

propertiesFileName이 우선적으로 로드되고, defaultPropertiesFileName은 그 이후에 기본값을 제공을 하기 때문에 계속 release.properties를 바라 보고 있었기에 build type에 맞는 properties를 load할 수 있게 수정

## 체크리스트
- [x] 빌드 확인
- [x] debug/release에 따라 정상적으로 api domain이 바뀌는지

## 동작 화면

![image](https://github.com/user-attachments/assets/ef3cec0a-a0f6-4d38-8049-295e9e4d708c)

## 살려주세요

