### PR TITLE
[SCRUM-113] release build 난독화 되게 수정

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,7 +32,7 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-project.txt"

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
 
 android {
     namespace = "com.mohanyang.data"
+    defaultConfig {
+        consumerProguardFiles("consumer-rules.pro")
+    }
 }
 
 dependencies {

--- a/data/consumer-rules.pro
+++ b/data/consumer-rules.pro
@@ -1,0 +1,13 @@
+## coroutine
+-keep class kotlinx.coroutines.android.** {*;}
+-keepnames class kotlinx.coroutines.internal.MainDispatcherFactory { *; }
+-keepnames class kotlinx.coroutines.CoroutineExceptionHandler { *; }
+-keepclassmembernames class kotlinx.** {
+    volatile <fields>;
+}
+-dontwarn kotlinx.coroutines.**
+
+## Kotlin
+-keepattributes *Annotation*
+-keep class kotlin.** { *; }
+-keep class org.jetbrains.** { *; }


### PR DESCRIPTION
## 작업 내용

- `isMinifyEnabled = true` 처리
- CallAdapter 부분에서 난독화 에러나는 것이라서 정상적으로 처리될 수 있게 `core:data`의 proguard 수정

## 체크리스트
- [x] 빌드 확인

## 동작 화면

> release 빌드만 확인하면 댐

## 살려주세요

