### PR TITLE
[SCRUM-143] 휴식/집중시간 설정 실패처리시 에러 페이지 렌딩될 수 있게 수정

### DIFF
--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/time/PomodoroTimeSettingViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/time/PomodoroTimeSettingViewModel.kt
@@ -51,7 +51,6 @@ class PomodoroTimeSettingViewModel @Inject constructor(
             is PomodoroTimeSettingEvent.Submit -> {
                 updateState { copy(lastRequestAction = event) }
                 updatePomodoroCategoryTime()
-                setEffect(PomodoroTimeSettingEffect.GoToPomodoroSettingScreen)
             }
 
             is PomodoroTimeSettingEvent.ChangePickTime -> {
@@ -110,6 +109,7 @@ class PomodoroTimeSettingViewModel @Inject constructor(
                     isLoading = false,
                 )
             }
+            setEffect(PomodoroTimeSettingEffect.GoToPomodoroSettingScreen)
         }
     }
 }


### PR DESCRIPTION
## 작업 내용

- API 호출 직후에 화면 이동이 아닌 `getOrThrow` 롤 에러 확인 이후 effect 발생될 수 있게 수정

## 체크리스트
- [x] 빌드 확인
- [x] 기본 카테고리로 시간 설정했을 때 동작 화면처럼 실행이 되는지

## 동작 화면

[Screen_recording_20250405_125444.webm](https://github.com/user-attachments/assets/0dd9dc68-d065-43b2-b436-efad0e14c48f)

## 살려주세요

