### PR TITLE
[SCRUM-142] 카테고리 삭제 이후 카테고리 선택으로 돌아갈 수 있게 수정

### DIFF
--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/PomodoroCategoryBottomSheet.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/PomodoroCategoryBottomSheet.kt
@@ -46,7 +46,7 @@ fun PomodoroCategoryBottomSheet(
     modifier: Modifier = Modifier,
 ) {
     var showMoreMenuComponent by rememberSaveable { mutableStateOf(false) }
-    var categoryManageState: CategoryManageState by remember { mutableStateOf(CategoryManageState.DEFAULT) }
+    var categoryManageState: CategoryManageState by remember(categoryList) { mutableStateOf(CategoryManageState.DEFAULT) }
 
     PomodoroCategoryBottomSheet(
         categoryManageState = categoryManageState,


### PR DESCRIPTION
## 작업 내용

카테고리의 추가 삭제 이후에는 카테고리 선택 화면으로 되어야 하기에 `remember(key)` 에서 key로 list를 받게 해서 list가 변경이 되면 DEFAULT로 설정이 되게 수정

## 체크리스트
- [x] 빌드 확인
- [x] 카테고리 삭제 후 카테고리 선택으로 돌아가지는지

## 동작 화면

[Screen_recording_20250405_131814.webm](https://github.com/user-attachments/assets/2f43b863-d8d6-4599-82fe-858870e5cdeb)


## 살려주세요

