### PR TITLE
[SCRUM-131] QA들 처리

### DIFF
--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/CategoryNameVerifier.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/CategoryNameVerifier.kt
@@ -1,17 +1,21 @@
 package com.pomonyang.mohanyang.presentation.screen.home.category
 
+import com.pomonyang.mohanyang.presentation.model.category.PomodoroCategoryModel
 import com.pomonyang.mohanyang.presentation.screen.onboarding.naming.ValidationResult
+import kotlinx.collections.immutable.ImmutableList
 
 object CategoryNameVerifier {
 
     private const val NAME_MAX_LENGTH = 10
     private const val NAME_MIN_LENGTH = 1
 
-    fun validateCategoryName(name: String): ValidationResult {
-        // TODO 기존 카테고리 이름 리스트 가져와서 중복값 확인하는 로직 추가
-        return ValidationResult(
-            isValid = name.length in NAME_MIN_LENGTH..NAME_MAX_LENGTH,
-            message = if (name.length <= NAME_MAX_LENGTH) "" else "최대 ${NAME_MAX_LENGTH}자리까지 입력할 수 있어요.",
-        )
+    fun validateCategoryName(name: String, categoryList: ImmutableList<PomodoroCategoryModel>): ValidationResult {
+        return when {
+            categoryList.any { it.title == name } -> ValidationResult(false, "이미 존재하는 카테고리예요.")
+            else -> ValidationResult(
+                isValid = name.length in NAME_MIN_LENGTH..NAME_MAX_LENGTH,
+                message = if (name.length <= NAME_MAX_LENGTH) "" else "최대 ${NAME_MAX_LENGTH}자리까지 입력할 수 있어요.",
+            )
+        }
     }
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/CategorySettingElements.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/CategorySettingElements.kt
@@ -3,8 +3,10 @@ package com.pomonyang.mohanyang.presentation.screen.home.category
 import com.pomonyang.mohanyang.presentation.base.ViewEvent
 import com.pomonyang.mohanyang.presentation.base.ViewSideEffect
 import com.pomonyang.mohanyang.presentation.base.ViewState
+import com.pomonyang.mohanyang.presentation.model.category.PomodoroCategoryModel
 import com.pomonyang.mohanyang.presentation.screen.home.category.model.CategoryIcon
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 
 data class CategorySettingState(
@@ -12,6 +14,7 @@ data class CategorySettingState(
     val categoryName: String = "",
     val selectedCategoryIcon: CategoryIcon = CategoryIcon.CAT,
     val categoryIcons: ImmutableList<CategoryIcon> = CategoryIcon.entries.toImmutableList(),
+    val categoryList: ImmutableList<PomodoroCategoryModel> = persistentListOf(),
 ) : ViewState {
     fun isCreateMode(): Boolean = categoryNo == null
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/CategorySettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/CategorySettingScreen.kt
@@ -17,7 +17,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -78,7 +77,7 @@ fun CategorySettingRoute(
     val keyboardController = LocalSoftwareKeyboardController.current
 
     LaunchedEffect(name) {
-        nameValidationResult = categoryNameValidator.validateCategoryName(name)
+        nameValidationResult = categoryNameValidator.validateCategoryName(name, state.categoryList)
     }
 
     categorySettingViewModel.effects.collectWithLifecycle { effect ->

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/CategorySettingScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/CategorySettingScreen.kt
@@ -230,7 +230,7 @@ private fun CategoryEditIcon(
                 .absoluteOffset(x = 52.dp, y = 44.dp)
                 .background(
                     color = MnTheme.backgroundColorScheme.inverse,
-                    shape = CircleShape,
+                    shape = RoundedCornerShape(MnRadius.medium),
                 )
                 .size(36.dp),
             contentAlignment = Alignment.Center,

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/CategorySettingViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/CategorySettingViewModel.kt
@@ -5,12 +5,16 @@ import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.pomonyang.mohanyang.data.repository.pomodoro.PomodoroSettingRepository
 import com.pomonyang.mohanyang.presentation.base.BaseViewModel
+import com.pomonyang.mohanyang.presentation.model.category.toCategoryModel
 import com.pomonyang.mohanyang.presentation.screen.home.CategorySetting
 import com.pomonyang.mohanyang.presentation.screen.home.category.model.CategoryIcon
 import com.pomonyang.mohanyang.presentation.screen.home.category.model.CategoryIcon.CategoryIconNavType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlin.reflect.typeOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 
 @HiltViewModel
@@ -41,6 +45,8 @@ class CategorySettingViewModel @Inject constructor(
                         selectedCategoryIcon = event.categoryIcon,
                     )
                 }
+
+                collectCategorySettingList()
             }
 
             is CategorySettingEvent.ClickEdit -> {
@@ -82,6 +88,16 @@ class CategorySettingViewModel @Inject constructor(
             CategorySettingEvent.DismissBottomSheet -> {
                 setEffect(CategorySettingSideEffect.DismissCategoryIconBottomSheet)
             }
+        }
+    }
+
+    private fun collectCategorySettingList() {
+        viewModelScope.launch {
+            pomodoroSettingRepository.getPomodoroSettingList()
+                .onEach { pomodoroSettingList ->
+                    updateState { copy(categoryList = pomodoroSettingList.map { it.toCategoryModel() }.toImmutableList()) }
+                }
+                .launchIn(viewModelScope)
         }
     }
 }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/PomodoroCategoryBottomSheet.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/PomodoroCategoryBottomSheet.kt
@@ -3,11 +3,15 @@ package com.pomonyang.mohanyang.presentation.screen.home.category
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -15,14 +19,19 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.datasource.CollectionPreviewParameterProvider
 import com.mohanyang.presentation.R
 import com.pomonyang.mohanyang.presentation.designsystem.bottomsheet.MnBottomSheet
+import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButton
+import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonColorType
+import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonStyles
 import com.pomonyang.mohanyang.presentation.designsystem.button.text.MnTextButton
 import com.pomonyang.mohanyang.presentation.designsystem.button.text.MnTextButtonStyles
+import com.pomonyang.mohanyang.presentation.designsystem.dialog.MnDialog
 import com.pomonyang.mohanyang.presentation.designsystem.toast.MnToastSnackbarHost
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
 import com.pomonyang.mohanyang.presentation.model.category.PomodoroCategoryModel
@@ -35,6 +44,7 @@ import com.pomonyang.mohanyang.presentation.screen.home.setting.PomodoroSettingE
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableMap
 import kotlinx.coroutines.launch
 
 @Composable
@@ -83,8 +93,50 @@ private fun PomodoroCategoryBottomSheet(
     onCancelClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val selectedItems: MutableMap<Int, Boolean> = remember(categoryList) { mutableStateMapOf<Int, Boolean>() }
     val subTitle = if (categoryManageState.isEdit()) stringResource(R.string.change_category_edit_sub_title) else null
     val scope = rememberCoroutineScope()
+
+    var showDeleteAlertDialog by remember { mutableStateOf(false) }
+
+    if (showDeleteAlertDialog) {
+        MnDialog(
+            title = stringResource(R.string.dialog_delete_category_title),
+            subTitle = stringResource(R.string.dialog_delete_category_subtitle),
+            positiveButton = {
+                MnBoxButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = stringResource(R.string.common_cancel),
+                    onClick = { showDeleteAlertDialog = false },
+                    colors = MnBoxButtonColorType.tertiary,
+                    styles = MnBoxButtonStyles.medium,
+                )
+            },
+            negativeButton = {
+                MnBoxButton(
+                    modifier = Modifier.fillMaxWidth(),
+                    text = stringResource(R.string.delete_category),
+                    onClick = {
+                        showDeleteAlertDialog = false
+                        onAction(PomodoroSettingEvent.DeleteCategories(selectedItems.map { it.key }))
+                    },
+                    colors = MnBoxButtonColorType.secondary,
+                    styles = MnBoxButtonStyles.medium,
+                )
+            },
+            onDismissRequest = {
+                showDeleteAlertDialog = false
+            },
+        )
+    }
+
+    LaunchedEffect(categoryManageState) {
+        selectedItems.clear()
+        if (categoryManageState.isDefault()) {
+            selectedItems[initialCategoryNo] = true
+        }
+    }
+
     MnBottomSheet(
         onDismissRequest = { onAction(PomodoroSettingEvent.DismissCategoryDialog) },
         modifier = modifier,
@@ -110,16 +162,15 @@ private fun PomodoroCategoryBottomSheet(
     ) {
         Box {
             CategoryBottomSheetContents(
-                modifier = Modifier.padding(MnSpacing.xLarge),
+                selectedItems = selectedItems.toImmutableMap(),
                 categoryManageState = categoryManageState,
                 categoryList = categoryList,
-                currentSelectedCategoryNo = initialCategoryNo,
                 onCategorySelected = { onAction(PomodoroSettingEvent.SelectCategory(it.categoryNo)) },
                 onCategoryEdit = { onAction(PomodoroSettingEvent.ClickCategoryEdit(it)) },
-                onDeleteItemsClick = { onAction(PomodoroSettingEvent.DeleteCategories(it)) },
-                onSnackbarShow = {
-                    scope.launch { snackbarHostState.showSnackbar(it) }
-                },
+                onSnackbarShow = { scope.launch { snackbarHostState.showSnackbar(it) } },
+                onDeleteItemClick = { showDeleteAlertDialog = true },
+                onSelectItem = { selectedItems[it] = selectedItems[it]?.not() ?: false },
+                modifier = Modifier.padding(MnSpacing.xLarge),
             )
 
             AnimatedVisibility(

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/PomodoroCategoryBottomSheet.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/PomodoroCategoryBottomSheet.kt
@@ -93,6 +93,7 @@ private fun PomodoroCategoryBottomSheet(
         headerContents = {
             if (categoryManageState.isDefault()) {
                 CategoryBottomSheetHeaderContents(
+                    isVisibleAddButton = categoryList.size != 10,
                     onEditClick = {
                         onAction.invoke(PomodoroSettingEvent.ClickCategoryCreate)
                     },

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/component/CategoryBottomSheetContents.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/component/CategoryBottomSheetContents.kt
@@ -7,12 +7,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateMapOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -25,68 +19,30 @@ import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButton
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonColorType
 import com.pomonyang.mohanyang.presentation.designsystem.button.box.MnBoxButtonStyles
 import com.pomonyang.mohanyang.presentation.designsystem.button.select.MnSelectListItem
-import com.pomonyang.mohanyang.presentation.designsystem.dialog.MnDialog
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
 import com.pomonyang.mohanyang.presentation.model.category.PomodoroCategoryModel
 import com.pomonyang.mohanyang.presentation.screen.home.category.model.CategoryIcon
 import com.pomonyang.mohanyang.presentation.screen.home.category.model.CategoryManageState
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableMap
 import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.persistentMapOf
 
 @Composable
 fun CategoryBottomSheetContents(
     categoryList: ImmutableList<PomodoroCategoryModel>,
+    selectedItems: ImmutableMap<Int, Boolean>,
     categoryManageState: CategoryManageState,
-    currentSelectedCategoryNo: Int,
     onCategorySelected: (PomodoroCategoryModel) -> Unit,
     onCategoryEdit: (PomodoroCategoryModel) -> Unit,
-    onDeleteItemsClick: (List<Int>) -> Unit,
     onSnackbarShow: (String) -> Unit,
+    onDeleteItemClick: () -> Unit,
+    onSelectItem: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val selectedItems: MutableMap<Int, Boolean> = remember(categoryList) { mutableStateMapOf<Int, Boolean>() }
     val gridCells = if (categoryList.size == 1) GridCells.Fixed(1) else GridCells.Fixed(2)
     val context = LocalContext.current
-    var showDeleteAlertDialog by remember { mutableStateOf(false) }
-
-    if (showDeleteAlertDialog) {
-        MnDialog(
-            title = stringResource(R.string.dialog_delete_category_title),
-            subTitle = stringResource(R.string.dialog_delete_category_subtitle),
-            positiveButton = {
-                MnBoxButton(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = stringResource(R.string.common_cancel),
-                    onClick = { showDeleteAlertDialog = false },
-                    colors = MnBoxButtonColorType.tertiary,
-                    styles = MnBoxButtonStyles.medium,
-                )
-            },
-            negativeButton = {
-                MnBoxButton(
-                    modifier = Modifier.fillMaxWidth(),
-                    text = stringResource(R.string.delete_category),
-                    onClick = {
-                        showDeleteAlertDialog = false
-                        onDeleteItemsClick(selectedItems.map { it.key })
-                    },
-                    colors = MnBoxButtonColorType.secondary,
-                    styles = MnBoxButtonStyles.medium,
-                )
-            },
-            onDismissRequest = {
-                showDeleteAlertDialog = false
-            },
-        )
-    }
-
-    LaunchedEffect(categoryManageState) {
-        selectedItems.clear()
-        if (categoryManageState.isDefault()) {
-            selectedItems[currentSelectedCategoryNo] = true
-        }
-    }
 
     Column(modifier = modifier) {
         LazyVerticalGrid(
@@ -120,7 +76,7 @@ fun CategoryBottomSheetContents(
 
                             CategoryManageState.DELETE -> {
                                 if (isNonEditableItem.not()) {
-                                    selectedItems[item.categoryNo] = !selected
+                                    onSelectItem(item.categoryNo)
                                 } else {
                                     onSnackbarShow(context.getString(R.string.default_category_cannot_edit))
                                 }
@@ -139,7 +95,7 @@ fun CategoryBottomSheetContents(
             MnBoxButton(
                 modifier = Modifier.fillMaxWidth(),
                 text = stringResource(id = R.string.change_category_delete_count, selectedItems.values.count { it }),
-                onClick = { showDeleteAlertDialog = true },
+                onClick = onDeleteItemClick,
                 colors = buttonColor,
                 isEnabled = isEnabled,
                 styles = MnBoxButtonStyles.large,
@@ -209,10 +165,11 @@ private fun CategoryBottomSheetPreview(
         CategoryBottomSheetContents(
             categoryList = categoryList,
             categoryManageState = CategoryManageState.EDIT,
-            currentSelectedCategoryNo = 1,
+            selectedItems = persistentMapOf(),
+            onDeleteItemClick = {},
+            onSelectItem = {},
             onCategorySelected = {},
             onCategoryEdit = {},
-            onDeleteItemsClick = {},
             onSnackbarShow = {},
         )
     }

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/component/CategoryBottomSheetHeaderContents.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/home/category/component/CategoryBottomSheetHeaderContents.kt
@@ -11,6 +11,7 @@ import com.pomonyang.mohanyang.presentation.theme.MnTheme
 
 @Composable
 fun CategoryBottomSheetHeaderContents(
+    isVisibleAddButton: Boolean,
     onEditClick: () -> Unit,
     onMoreMenuClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -19,10 +20,12 @@ fun CategoryBottomSheetHeaderContents(
         modifier = modifier,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        MnIconButton(
-            onClick = onEditClick,
-            iconResourceId = R.drawable.ic_plus,
-        )
+        if (isVisibleAddButton) {
+            MnIconButton(
+                onClick = onEditClick,
+                iconResourceId = R.drawable.ic_plus,
+            )
+        }
         MnIconButton(
             onClick = onMoreMenuClick,
             iconResourceId = R.drawable.ic_ellipsis,
@@ -35,6 +38,7 @@ fun CategoryBottomSheetHeaderContents(
 private fun CategoryBottomSheetHeaderPreview() {
     MnTheme {
         CategoryBottomSheetHeaderContents(
+            isVisibleAddButton = true,
             onEditClick = {},
             onMoreMenuClick = {},
         )


### PR DESCRIPTION
## 작업 내용

- [SCRUM-146](https://pomonyangteam.atlassian.net/browse/SCRUM-146)
- [SCRUM-147](https://pomonyangteam.atlassian.net/browse/SCRUM-147)
- [SCRUM-148](https://pomonyangteam.atlassian.net/browse/SCRUM-148)
- [SCRUM-149](https://pomonyangteam.atlassian.net/browse/SCRUM-149)
- [SCRUM-150](https://pomonyangteam.atlassian.net/browse/SCRUM-150)

## 체크리스트
- [ ] 빌드 확인
- [ ] 중복 카테고리를 입력했을 때 서버 통신 없이 에러 메세지 표시 되는지
- [ ] 삭제 다이얼로그 정중앙 표시
- [ ] 카테고리 추가의 아이콘 radius 값 수정된 부분
- [ ] 카테고리가 10개일 때 `+` 버튼 없어지는지

## 동작 화면

[Screen_recording_20250406_201253.webm](https://github.com/user-attachments/assets/6b701769-9452-458f-9647-4eb633a76c3d)

## 살려주세요

