### PR TITLE
fix: 마이페이지 > 고양이 변경 후 알람 세팅 초기화되는 버그 수정

### DIFF
--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/OnboardingNavigator.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/OnboardingNavigator.kt
@@ -62,19 +62,17 @@ fun NavGraphBuilder.onboardingScreen(
 
             val routeData = navBackStackEntry.toRoute<OnboardingSelectCat>()
             val destination = CatSettingDestination.valueOf(routeData.destination)
+            val isOnBoardingProcess = destination == CatSettingDestination.POMODORO
 
             OnboardingSelectCatRoute(
+                isOnBoardingProcess = isOnBoardingProcess,
                 selectedCatNo = routeData.selectedCatNo,
                 onBackClick = { navHostController.popBackStack() },
                 onStartClick = { catNo, catName, catTypeName ->
-                    when (destination) {
-                        CatSettingDestination.POMODORO -> {
-                            navHostController.navigate(OnboardingNamingCat(catNo = catNo, catName = catName, destination = destination.name, catTypeName = catTypeName))
-                        }
-
-                        CatSettingDestination.MY_PAGE -> {
-                            navHostController.popBackStack()
-                        }
+                    if (isOnBoardingProcess) {
+                        navHostController.navigate(OnboardingNamingCat(catNo = catNo, catName = catName, destination = destination.name, catTypeName = catTypeName))
+                    } else {
+                        navHostController.popBackStack()
                     }
                 },
                 onShowSnackBar = {

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/select/OnboardingSelectCatElements.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/select/OnboardingSelectCatElements.kt
@@ -19,7 +19,7 @@ sealed interface SelectCatEvent : ViewEvent {
     data class Init(val catNo: Int? = null) : SelectCatEvent
     data class OnSelectType(val type: CatType) : SelectCatEvent
     data object OnStartClick : SelectCatEvent
-    data object OnGrantedAlarmPermission : SelectCatEvent
+    data object InitDefaultAlarmSetting : SelectCatEvent
     data object OnClickRetry : SelectCatEvent
 }
 

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/select/OnboardingSelectCatScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/select/OnboardingSelectCatScreen.kt
@@ -55,6 +55,7 @@ import kotlinx.collections.immutable.toPersistentList
 
 @Composable
 fun OnboardingSelectCatRoute(
+    isOnBoardingProcess: Boolean,
     selectedCatNo: Int,
     onBackClick: () -> Unit,
     onStartClick: (Int, String, String) -> Unit,
@@ -85,7 +86,7 @@ fun OnboardingSelectCatRoute(
     }
 
     NotificationPermissionEffect {
-        onboardingSelectCatViewModel.handleEvent(SelectCatEvent.OnGrantedAlarmPermission)
+        if (isOnBoardingProcess) onboardingSelectCatViewModel.handleEvent(SelectCatEvent.InitDefaultAlarmSetting)
     }
 
     LaunchedEffect(Unit) {

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/select/OnboardingSelectCatViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/select/OnboardingSelectCatViewModel.kt
@@ -62,7 +62,7 @@ class OnboardingSelectCatViewModel @Inject constructor(
                 }
             }
 
-            is SelectCatEvent.OnGrantedAlarmPermission -> {
+            is SelectCatEvent.InitDefaultAlarmSetting -> {
                 viewModelScope.launch {
                     pushAlarmRepository.setInterruptNotification(true)
                     pushAlarmRepository.setTimerNotification(true)


### PR DESCRIPTION
## 작업 내용
- 마이페이지 > 고양이 선택 화면 > 페이지 복귀 시 설정한 알림(집중시간, 딴짓방해) 값이 default로 초기화 되는 버그 수정
- 온보딩 프로세스에서만 초기화되도록 변경
- SelectCat Event 이름 변경 : InitDefaultAlarmSetting

## 체크리스트
- [x] 빌드 확인
- [x] 마이페이지에서 수정한 알람 설정값이 유지되는 지 확인

## 동작 화면

## 살려주세요

