### PR TITLE
[FIX] 백스택 이동 시 바텀 메뉴 반영 안되는 이슈 수정

### DIFF
--- a/app/src/main/java/com/pomonyang/mohanyang/ui/MohaNyangApp.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/ui/MohaNyangApp.kt
@@ -17,10 +17,8 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -43,7 +41,7 @@ import com.pomonyang.mohanyang.presentation.designsystem.token.MnRadius
 import com.pomonyang.mohanyang.presentation.designsystem.token.MnSpacing
 import com.pomonyang.mohanyang.presentation.screen.home.Home
 import com.pomonyang.mohanyang.presentation.screen.mypage.MyPage
-import com.pomonyang.mohanyang.presentation.screen.statistics.Statistics
+import com.pomonyang.mohanyang.presentation.screen.statistics.StatisticsGraph
 import com.pomonyang.mohanyang.presentation.theme.MnTheme
 import com.pomonyang.mohanyang.presentation.util.ThemePreviews
 import com.pomonyang.mohanyang.ui.component.MohaNyangBottomBar
@@ -70,7 +68,6 @@ private fun MohaNyangApp(
 ) {
     var snackbarIconRes by remember { mutableStateOf<Int?>(null) }
     val navHostController = mohaNyangAppState.navHostController
-    var selectedNavigationIndex by rememberSaveable { mutableIntStateOf(0) }
 
     val items = persistentListOf(
         BottomNavItem(
@@ -80,7 +77,7 @@ private fun MohaNyangApp(
             label = stringResource(R.string.bottom_navigation_home),
         ),
         BottomNavItem(
-            route = Statistics,
+            route = StatisticsGraph,
             iconRes = PresentationR.drawable.ic_chart_bar,
             selectedIconRes = PresentationR.drawable.ic_chart_bar_fill,
             label = stringResource(R.string.bottom_navigation_statistics),
@@ -112,8 +109,7 @@ private fun MohaNyangApp(
                 MohaNyangBottomBar(
                     navController = navHostController,
                     items = items,
-                    selectedIndex = selectedNavigationIndex,
-                    onItemSelected = { selectedNavigationIndex = it },
+                    currentBottomRootRoute = mohaNyangAppState.currentBottomRootRoute,
                 )
             }
         },

--- a/app/src/main/java/com/pomonyang/mohanyang/ui/MohaNyangAppState.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/ui/MohaNyangAppState.kt
@@ -77,4 +77,7 @@ class MohaNyangAppState(
                 }
             } ?: previousDestination.value
         }
+
+    val currentBottomRootRoute: String?
+        @Composable get() = currentDestination?.parent?.route
 }

--- a/app/src/main/java/com/pomonyang/mohanyang/ui/component/MohaNyangBottomBar.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/ui/component/MohaNyangBottomBar.kt
@@ -31,8 +31,7 @@ import kotlinx.collections.immutable.persistentListOf
 internal fun MohaNyangBottomBar(
     navController: NavHostController,
     items: PersistentList<BottomNavItem>,
-    selectedIndex: Int,
-    onItemSelected: (index: Int) -> Unit,
+    currentBottomRootRoute: String? = null,
 ) {
     Row(
         verticalAlignment = Alignment.CenterVertically,
@@ -50,7 +49,6 @@ internal fun MohaNyangBottomBar(
                     .weight(1f)
                     .padding(vertical = MnSpacing.small)
                     .noRippleClickable {
-                        onItemSelected(index)
                         navController.navigate(bottomNavItem.route) {
                             popUpTo(navController.graph.findStartDestination().id) {
                                 saveState = true
@@ -60,7 +58,8 @@ internal fun MohaNyangBottomBar(
                         }
                     },
             ) {
-                val iconRes = if (selectedIndex == index) {
+                val isItemSelected = currentBottomRootRoute == bottomNavItem.route::class.qualifiedName
+                val iconRes = if (isItemSelected) {
                     bottomNavItem.selectedIconRes
                 } else {
                     bottomNavItem.iconRes
@@ -102,8 +101,7 @@ private fun MohaNyangBottomBarPreview() {
                     label = "프로필",
                 ),
             ),
-            selectedIndex = 0,
-            onItemSelected = {},
+            currentBottomRootRoute = Home::class.qualifiedName,
         )
     }
 }


### PR DESCRIPTION
## 작업 내용

- backstack 이동 시 바텀 싱크 안맞는 문제 

https://github.com/user-attachments/assets/de65c691-2a50-4fec-9fe5-b5bbdd089314

- currentRoute 기준으로 동적 확인하도록 수정
   - 통계 / 마이페이지 모두 뒤로가기 시 홈으로 감

## 체크리스트
- [x] 빌드 확인
- [x] 백스택 이동 시 싱크 맞는지 확인

## 동작 화면

https://github.com/user-attachments/assets/b452eaed-6d67-40e0-ba8a-56289791d848


## 살려주세요

