### PR TITLE
[Fix] 오프라인 진입 제어 + 로그인 프로세스 수정

### DIFF
--- a/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/MainActivity.kt
@@ -20,7 +20,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.lifecycleScope
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.navigation.compose.rememberNavController
 import androidx.startup.AppInitializer
@@ -41,7 +40,6 @@ import com.pomonyang.mohanyang.presentation.util.MnNotificationManager
 import com.pomonyang.mohanyang.presentation.util.MohanyangEventLogger
 import com.pomonyang.mohanyang.presentation.util.collectWithLifecycle
 import com.pomonyang.mohanyang.ui.MohaNyangApp
-import com.pomonyang.mohanyang.ui.MohaNyangAppState
 import com.pomonyang.mohanyang.ui.rememberMohaNyangAppState
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
@@ -64,32 +62,18 @@ class MainActivity : ComponentActivity() {
 
     private var keepSplashOnScreen = true
 
+    private var splashTime = 0L
+
     override fun onCreate(savedInstanceState: Bundle?) {
         handleSplashScreen()
         super.onCreate(savedInstanceState)
-
+        viewModel.handleEvent(MainEvent.Init)
         configureAppStartup()
 
         setContent {
             val activity = (LocalContext.current as? Activity)
-
             val state by viewModel.state.collectAsStateWithLifecycle()
-            val coroutineScope = rememberCoroutineScope()
-
-            val mohaNyangAppState = rememberMohaNyangAppState(
-                isNewUser = viewModel.checkIfNewUser(),
-                networkMonitor = networkMonitor,
-                coroutineScope = coroutineScope,
-                navHostController = rememberNavController().apply {
-                    NavigationViewTrackingEffect(navController = this)
-                },
-            )
-
             var showDialog by remember { mutableStateOf(false) }
-
-            LaunchedEffect(Unit) {
-                viewModel.handleEvent(MainEvent.Init)
-            }
 
             viewModel.effects.collectWithLifecycle { effect ->
                 when (effect) {
@@ -125,7 +109,6 @@ class MainActivity : ComponentActivity() {
                     AppScreen(
                         modifier = Modifier,
                         viewState = state,
-                        mohaNyangAppState = mohaNyangAppState,
                         eventLogger = eventLogger,
                     )
                 }
@@ -137,9 +120,19 @@ class MainActivity : ComponentActivity() {
     fun AppScreen(
         modifier: Modifier,
         viewState: MainState,
-        mohaNyangAppState: MohaNyangAppState,
         eventLogger: MohanyangEventLogger,
     ) {
+        LaunchedEffect(viewState.isDataFetched) {
+            if (viewState.isDataFetched) {
+                val loadDuration = System.currentTimeMillis() - splashTime
+                val loadRemainTime = (SPLASH_DELAY - loadDuration).coerceAtLeast(0)
+                if (loadRemainTime > 0) {
+                    delay(loadRemainTime)
+                }
+                keepSplashOnScreen = false
+            }
+        }
+
         when {
             viewState.isInternalError -> ServerErrorScreen(onClickNavigateToHome = { })
             viewState.isInvalidError ->
@@ -149,11 +142,17 @@ class MainActivity : ComponentActivity() {
                 )
 
             viewState.isLoading -> LoadingScreen(modifier = modifier)
-            else -> {
-                MohaNyangApp(
-                    mohaNyangAppState = mohaNyangAppState,
-                    logger = eventLogger,
+            viewState.isDataFetched -> {
+                val coroutineScope = rememberCoroutineScope()
+                val mohaNyangAppState = rememberMohaNyangAppState(
+                    isNewUser = viewState.isNewUser!!,
+                    networkMonitor = networkMonitor,
+                    coroutineScope = coroutineScope,
+                    navHostController = rememberNavController().apply {
+                        NavigationViewTrackingEffect(navController = this)
+                    },
                 )
+                MohaNyangApp(mohaNyangAppState = mohaNyangAppState, logger = eventLogger)
             }
         }
     }
@@ -178,11 +177,8 @@ class MainActivity : ComponentActivity() {
     }
 
     private fun handleSplashScreen() {
+        splashTime = System.currentTimeMillis()
         installSplashScreen().setKeepOnScreenCondition { keepSplashOnScreen }
-        lifecycleScope.launch {
-            delay(SPLASH_DELAY)
-            keepSplashOnScreen = false
-        }
     }
 
     override fun onResume() {

--- a/app/src/main/java/com/pomonyang/mohanyang/MainElements.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/MainElements.kt
@@ -9,7 +9,10 @@ data class MainState(
     override val isInternalError: Boolean = false,
     override val isInvalidError: Boolean = false,
     override val lastRequestAction: MainEvent? = null,
-) : NetworkViewState()
+    val isNewUser: Boolean? = null,
+) : NetworkViewState() {
+    val isDataFetched = isLoading.not() && isNewUser != null
+}
 
 sealed interface MainEvent : ViewEvent {
     data object Init : MainEvent

--- a/app/src/main/java/com/pomonyang/mohanyang/MainViewModel.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/MainViewModel.kt
@@ -103,8 +103,8 @@ class MainViewModel @Inject constructor(
 
     // 오프라인 상태일 때 실행할 초기화 로직
     private fun onOffline() = scope.launch {
-        val isNewUser = checkIfNewUser()
-        setupUserAndNavigate(isNewUser)
+        pomodoroTimerRepository.savePomodoroCacheData()
+        setEffect(MainEffect.ShowDialog)
     }
 
     private suspend fun setupUserAndNavigate(isNewUser: Boolean) {

--- a/app/src/main/java/com/pomonyang/mohanyang/MainViewModel.kt
+++ b/app/src/main/java/com/pomonyang/mohanyang/MainViewModel.kt
@@ -97,7 +97,9 @@ class MainViewModel @Inject constructor(
     private fun onOnline() = scope.launch {
         fetchFcmToken()
         fetchUserInfo().onSuccess {
-            setupUserAndNavigate(it.isNewUser())
+            val isNewUser = it.isNewUser()
+            updateState { copy(isNewUser = isNewUser) }
+            setupUserAndNavigate(isNewUser)
         }.getOrThrow()
     }
 
@@ -116,8 +118,6 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun checkIfNewUser() = userRepository.isNewUser()
-
     private suspend fun fetchUserInfo(): Result<UserInfoResponse> = runCatching {
         getTokenByDeviceIdUseCase().getOrThrow()
         val userInfo = userRepository.fetchMyInfo().getOrThrow()
@@ -129,8 +129,10 @@ class MainViewModel @Inject constructor(
         if (!networkMonitor.isConnected) return
         scope.launch {
             val userInfo = fetchUserInfo().getOrThrow()
+            val isNewUser = userInfo.isNewUser()
+            updateState { copy(isNewUser = isNewUser) }
+            setupUserAndNavigate(isNewUser)
             setEffect(MainEffect.DismissDialog)
-            setupUserAndNavigate(userInfo.isNewUser())
         }
     }
 

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/user/UserRepository.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/user/UserRepository.kt
@@ -6,7 +6,6 @@ import java.time.LocalDate
 
 interface UserRepository {
     suspend fun getDeviceId(): String
-    fun isNewUser(): Boolean
     suspend fun login(deviceId: String): Result<TokenResponse>
     suspend fun saveToken(accessToken: String, refreshToken: String)
     suspend fun fetchMyInfo(): Result<UserInfoResponse>

--- a/data/src/main/java/com/pomonyang/mohanyang/data/repository/user/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/pomonyang/mohanyang/data/repository/user/UserRepositoryImpl.kt
@@ -11,7 +11,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
 import javax.inject.Inject
-import kotlinx.coroutines.runBlocking
 
 internal class UserRepositoryImpl @Inject constructor(
     private val deviceLocalDataStore: DeviceIdLocalDataSource,
@@ -21,8 +20,6 @@ internal class UserRepositoryImpl @Inject constructor(
     private val authService: AuthService,
 ) : UserRepository {
     override suspend fun getDeviceId() = deviceLocalDataStore.getDeviceId()
-
-    override fun isNewUser(): Boolean = runBlocking { tokenLocalDataSource.getAccessToken().isEmpty() || userLocalDataSource.getUserInfo().isNewUser() }
 
     override suspend fun login(deviceId: String) = authService.getTokenByDeviceId(TokenRequest(deviceId))
 

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/guide/OnboardingGuideScreen.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/guide/OnboardingGuideScreen.kt
@@ -52,10 +52,6 @@ internal fun OnboardingGuideRoute(
     modifier: Modifier = Modifier,
     onboardingViewModel: OnboardingGuideViewModel = hiltViewModel(),
 ) {
-    LaunchedEffect(Unit) {
-        onboardingViewModel.handleEvent(OnboardingGuideEvent.Init)
-    }
-
     OnboardingGuideScreen(
         modifier = modifier,
         onHomeClick = onStartClick,

--- a/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/guide/OnboardingGuideViewModel.kt
+++ b/presentation/src/main/java/com/pomonyang/mohanyang/presentation/screen/onboarding/guide/OnboardingGuideViewModel.kt
@@ -1,6 +1,5 @@
 package com.pomonyang.mohanyang.presentation.screen.onboarding.guide
 
-import androidx.lifecycle.viewModelScope
 import com.pomonyang.mohanyang.data.repository.user.UserRepository
 import com.pomonyang.mohanyang.presentation.base.BaseViewModel
 import com.pomonyang.mohanyang.presentation.base.ViewEvent
@@ -8,12 +7,8 @@ import com.pomonyang.mohanyang.presentation.base.ViewSideEffect
 import com.pomonyang.mohanyang.presentation.base.ViewState
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
-import kotlinx.coroutines.launch
-import timber.log.Timber
 
-sealed class OnboardingGuideSideEffect : ViewSideEffect {
-    data object NavigateToHome : OnboardingGuideSideEffect()
-}
+sealed class OnboardingGuideSideEffect : ViewSideEffect
 
 sealed class OnboardingGuideEvent : ViewEvent {
     data object Init : OnboardingGuideEvent()
@@ -28,35 +23,5 @@ class OnboardingGuideViewModel @Inject constructor(
 
     override fun setInitialState(): OnboardingGuideUiState = OnboardingGuideUiState(isNewUser = true)
 
-    override fun handleEvent(event: OnboardingGuideEvent) {
-        when (event) {
-            is OnboardingGuideEvent.Init -> {
-                login()
-            }
-        }
-    }
-
-    private fun login() {
-        viewModelScope.launch {
-            if (userRepository.isNewUser()) {
-                getTokenByDeviceId()
-            }
-
-            setEffect(OnboardingGuideSideEffect.NavigateToHome)
-        }
-    }
-
-    private suspend fun getTokenByDeviceId() {
-        val deviceId = userRepository.getDeviceId()
-        if (deviceId.isNotEmpty()) {
-            userRepository.login(deviceId).onSuccess {
-                userRepository.saveToken(
-                    accessToken = it.accessToken,
-                    refreshToken = it.refreshToken,
-                )
-            }.onFailure {
-                Timber.e("token fail: $it")
-            }
-        }
-    }
+    override fun handleEvent(event: OnboardingGuideEvent) {}
 }


### PR DESCRIPTION
## 작업 내용
- 오프라인 진입 제한
- 재설치/신규 설치 시 Token API 중복 호출로 device duplicate 에러가 가끔 뜨는 현상 해결

## 체크리스트
- [x] 빌드 확인
- [x] 임시로 디바이스 아이디 변경해서 new user 테스트
- [x] 재설치 후 통계 기록 잘 유지되는 지 확인
- [x] 오프라인으로 앱 진입할 때 다이얼 보이는 지 확인

## 동작 화면

- 오프라인 진입 제한

https://github.com/user-attachments/assets/6f0407b3-5657-430b-b5fc-3695b027a695

- 신규 가입자 진입

https://github.com/user-attachments/assets/02e41663-3b2c-4399-b100-7b3793f0a666



## 살려주세요

